### PR TITLE
feat: add underlying Command accessors to *CommandWrap

### DIFF
--- a/src/generic_wrap.rs
+++ b/src/generic_wrap.rs
@@ -34,6 +34,21 @@ macro_rules! Wrap {
 				}
 			}
 
+			/// Get a reference to the wrapped command.
+			pub fn command(&self) -> &$command {
+				&self.command
+			}
+
+			/// Get a mutable reference to the wrapped command.
+			pub fn command_mut(&mut self) -> &mut $command {
+				&mut self.command
+			}
+
+			/// Get the wrapped command.
+			pub fn into_command(self) -> $command {
+				self.command
+			}
+
 			/// Add a wrapper to the command.
 			///
 			/// This is a lazy method, and the wrapper is not actually applied until `spawn` is

--- a/src/std/process_group.rs
+++ b/src/std/process_group.rs
@@ -67,6 +67,13 @@ impl ProcessGroupChild {
 			pgid,
 		}
 	}
+
+	/// Get the process group ID of this child process.
+	///
+	/// See: [`man 'setpgid(2)'`](https://www.man7.org/linux/man-pages/man2/setpgid.2.html)
+	pub fn pgid(&self) -> Pid {
+		self.pgid
+	}
 }
 
 impl StdCommandWrapper for ProcessGroup {

--- a/src/tokio/process_group.rs
+++ b/src/tokio/process_group.rs
@@ -72,6 +72,13 @@ impl ProcessGroupChild {
 			pgid,
 		}
 	}
+
+	/// Get the process group ID of this child process.
+	///
+	/// See: [`man 'setpgid(2)'`](https://www.man7.org/linux/man-pages/man2/setpgid.2.html)
+	pub fn pgid(&self) -> Pid {
+		self.pgid
+	}
 }
 
 impl TokioCommandWrapper for ProcessGroup {


### PR DESCRIPTION
Port of https://github.com/watchexec/command-group/pull/27.

Hello! I'm implementing [`command-error`](https://docs.rs/command-error/latest/command_error/), a crate that provides nicer error messages for commands, like this:

```
`sh` failed: exit status: 1
Command failed: `sh -c 'echo puppy; false'`
Stdout:
  puppy
```

I'd like to add optional support for the `process-wrap` crate (https://github.com/9999years/command-error/issues/2). Because traits can only be implemented once per type (and I think a generic trait would have poor ergonomics here), I'm attempting to `impl command_error::CommandExt for process_wrap::std::StdCommandWrap`, but it's not possible to access the underlying `Command` (to produce the name of the program that was run for error messages) with the current API.

Therefore, this PR adds getters to access the `Command` field of `StdCommandWrap`.