### PR TITLE
Fix compilation error (cannot find value `leader` in this scope)

### DIFF
--- a/src/tokio/process_group.rs
+++ b/src/tokio/process_group.rs
@@ -93,8 +93,8 @@ impl TokioCommandWrapper for ProcessGroup {
 		}
 
 		#[cfg(not(tokio_unstable))]
-		let leader = self.leader;
 		unsafe {
+			let leader = self.leader;
 			command.pre_exec(move || {
 				setpgid(Pid::this(), leader)
 					.map_err(Error::from)


### PR DESCRIPTION
Hi, updating watchexec I've got the following error, seemed easy so I'm sending the PR without a bug report.

```
error[E0425]: cannot find value `leader` in this scope
  --> $HOME/.cargo/registry/src/index.crates.io-6f17d22bba15001f/process-wrap-8.0.2/src/tokio/process_group.rs:99:26
   |
99 |                 setpgid(Pid::this(), leader)
   |                                      ^^^^^^
   |
help: you might have meant to use the available field
   |
99 |                 setpgid(Pid::this(), self.leader)
   |                                      +++++
```

PS: Thanks for the awesome libs.