### PR TITLE
feat: update nix to 0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.7.0",
  "cfg-if",
@@ -538,7 +538,7 @@ version = "8.2.0"
 dependencies = [
  "futures",
  "indexmap",
- "nix 0.29.0",
+ "nix 0.30.1",
  "remoteprocess",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { version = "0.1.40", optional = true }
 # a breaking change, so long as it remains ~6 months below current
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29.0", default-features = false, features = ["fs", "poll", "signal"], optional = true }
+nix = { version = "0.30.1", default-features = false, features = ["fs", "poll", "signal"], optional = true }
 # note: bumping the nix version doesn't require a breaking change,
 # as process-wrap is carefully designed to never expose nix's types
 


### PR DESCRIPTION
This PR updates `nix` to add partial support for Cygwin. It will be enough to port `rust-analyzer` to Cygwin.