### PR TITLE
fix: only extract active wrapper during spawn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +490,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pin-project-lite"
@@ -542,6 +558,7 @@ dependencies = [
  "remoteprocess",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "windows",
 ]
 
@@ -661,6 +678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +737,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -769,6 +805,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -792,6 +854,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ windows = { version = "0.61.1", optional = true }
 [dev-dependencies]
 remoteprocess = "0.5.0"
 tokio = { version = "1.38.2", features = ["io-util", "macros", "process", "rt", "rt-multi-thread", "time"] }
+tracing-subscriber = "0.3.19"
 
 [features]
 default = ["creation-flags", "job-object", "kill-on-drop", "process-group", "process-session", "tracing"]

--- a/src/std/job_object.rs
+++ b/src/std/job_object.rs
@@ -40,7 +40,7 @@ impl StdCommandWrapper for JobObject {
 	fn pre_spawn(&mut self, command: &mut Command, core: &StdCommandWrap) -> Result<()> {
 		let mut flags = CREATE_SUSPENDED;
 		#[cfg(feature = "creation-flags")]
-		if let Some(CreationFlags(user_flags)) = core.get_wrap::<CreationFlags>() {
+		if let Some(CreationFlags(user_flags)) = core.get_wrap::<CreationFlags>().as_deref() {
 			flags |= *user_flags;
 		}
 

--- a/src/tokio/job_object.rs
+++ b/src/tokio/job_object.rs
@@ -41,7 +41,7 @@ impl TokioCommandWrapper for JobObject {
 	fn pre_spawn(&mut self, command: &mut Command, core: &TokioCommandWrap) -> Result<()> {
 		let mut flags = CREATE_SUSPENDED;
 		#[cfg(feature = "creation-flags")]
-		if let Some(CreationFlags(user_flags)) = core.get_wrap::<CreationFlags>() {
+		if let Some(CreationFlags(user_flags)) = core.get_wrap::<CreationFlags>().as_deref() {
 			flags |= *user_flags;
 		}
 

--- a/tests/std_windows/mod.rs
+++ b/tests/std_windows/mod.rs
@@ -1,7 +1,7 @@
 mod prelude {
 	pub use std::{
 		io::{Read, Result, Write},
-		process::Stdio,
+		process::{Command, Stdio},
 		thread::sleep,
 		time::Duration,
 	};
@@ -9,6 +9,12 @@ mod prelude {
 	pub use process_wrap::std::*;
 
 	pub const DIE_TIME: Duration = Duration::from_millis(1000);
+}
+
+fn init() {
+	tracing_subscriber::fmt()
+		.with_max_level(tracing::Level::DEBUG)
+		.init();
 }
 
 mod id_same_as_inner;

--- a/tests/std_windows/mod.rs
+++ b/tests/std_windows/mod.rs
@@ -15,6 +15,7 @@ mod id_same_as_inner;
 mod inner_read_stdout;
 mod into_inner_write_stdin;
 mod kill_and_try_wait;
+mod read_creation_flags;
 mod try_wait_after_die;
 mod wait_after_die;
 mod wait_twice;

--- a/tests/std_windows/read_creation_flags.rs
+++ b/tests/std_windows/read_creation_flags.rs
@@ -1,9 +1,6 @@
-use std::{
-	process::Command,
-	sync::{
-		atomic::{AtomicU32, Ordering},
-		Arc,
-	},
+use std::sync::{
+	atomic::{AtomicU32, Ordering},
+	Arc,
 };
 
 use windows::Win32::System::Threading::CREATE_NO_WINDOW;
@@ -28,6 +25,8 @@ impl StdCommandWrapper for FlagSpy {
 
 #[test]
 fn retrieve_flags() -> Result<()> {
+	super::init();
+
 	let spy = FlagSpy::default();
 	let _ = StdCommandWrap::with_new("powershell.exe", |command| {
 		command.arg("/C").arg("echo hello").stdout(Stdio::piped());

--- a/tests/std_windows/read_creation_flags.rs
+++ b/tests/std_windows/read_creation_flags.rs
@@ -1,0 +1,42 @@
+use std::{
+	process::Command,
+	sync::{
+		atomic::{AtomicU32, Ordering},
+		Arc,
+	},
+};
+
+use windows::Win32::System::Threading::CREATE_NO_WINDOW;
+
+use super::prelude::*;
+
+#[derive(Clone, Debug, Default)]
+pub struct FlagSpy {
+	pub flags: Arc<AtomicU32>,
+}
+
+impl StdCommandWrapper for FlagSpy {
+	fn pre_spawn(&mut self, _command: &mut Command, core: &StdCommandWrap) -> Result<()> {
+		#[cfg(feature = "creation-flags")]
+		if let Some(CreationFlags(user_flags)) = core.get_wrap::<CreationFlags>().as_deref() {
+			self.flags.store(user_flags.0, Ordering::Relaxed);
+		}
+
+		Ok(())
+	}
+}
+
+#[test]
+fn retrieve_flags() -> Result<()> {
+	let spy = FlagSpy::default();
+	let _ = StdCommandWrap::with_new("powershell.exe", |command| {
+		command.arg("/C").arg("echo hello").stdout(Stdio::piped());
+	})
+	.wrap(CreationFlags(CREATE_NO_WINDOW))
+	.wrap(spy.clone())
+	.spawn()?;
+
+	assert_eq!(spy.flags.load(Ordering::Relaxed), CREATE_NO_WINDOW.0);
+
+	Ok(())
+}


### PR DESCRIPTION
Fixes #19 

Noting this is a breaking change due to changing

```rust
pub fn get_wrap<W: $wrapper + 'static>(&self) -> Option<&W>
```

to

```rust
pub fn get_wrap<W: $wrapper + 'static>(&self) -> Option<::std::cell::Ref<W>>
```

There might be a way to revert that change and/or not expose the `Ref` but I can't see it right now.


---

Reading list

- https://docs.rs/process-wrap/latest/x86_64-pc-windows-msvc/src/process_wrap/std/job_object.rs.html
- https://docs.rs/process-wrap/latest/x86_64-pc-windows-msvc/src/process_wrap/std/creation_flags.rs.html
- https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/System/Threading/constant.CREATE_SUSPENDED.html
- https://doc.rust-lang.org/stable/std/cell/struct.Ref.html#method.clone
- https://github.com/watchexec/process-wrap/blob/main/src/generic_wrap.rs