### PR TITLE
feat: change child wrapper inner()s to return one layer down

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - windows
         toolchain:
           - stable
-          - 1.77.0
+          - 1.86.0
         features:
           - tokio1
           - std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,6 @@ tokio = { version = "1.38.2", features = ["io-util", "macros", "process", "rt", 
 [features]
 default = ["creation-flags", "job-object", "kill-on-drop", "process-group", "process-session", "tracing"]
 
-## Enable Any trait bound on the ChildWrapper traits
-downcasting = []
-
 ## Enable internal tracing logs
 tracing = ["dep:tracing"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 edition = "2021"
 exclude = ["/bin", "/.github"]
-rust-version = "1.77.0"
+rust-version = "1.86.0"
 
 [dependencies]
 futures = { version = "0.3.30", optional = true }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **[API documentation][docs]**.
 - [Dual-licensed][copyright] with Apache 2.0 and MIT.
 - Successor to [command-group](https://github.com/watchexec/command-group).
-- Minimum Supported Rust Version: 1.77.0.
+- Minimum Supported Rust Version: 1.86.0.
   - Only the latest stable rustc version is supported.
   - MSRV increases will not incur major version bumps.
 

--- a/src/generic_wrap.rs
+++ b/src/generic_wrap.rs
@@ -230,20 +230,4 @@ macro_rules! Wrap {
 	};
 }
 
-macro_rules! MaybeAnyTrait {
-	(
-		$(#[$($attrss:tt)*])*
-		$v:vis trait $name:ident $body:tt
-	) => {
-		#[cfg(feature = "downcasting")]
-		$(#[$($attrss)*])*
-		$v trait $name: std::fmt::Debug + Send + Sync + std::any::Any $body
-
-		#[cfg(not(feature = "downcasting"))]
-		$(#[$($attrss)*])*
-		$v trait $name: std::fmt::Debug + Send + Sync $body
-	}
-}
-
-pub(crate) use MaybeAnyTrait;
 pub(crate) use Wrap;

--- a/src/std.rs
+++ b/src/std.rs
@@ -9,7 +9,7 @@
 //! ```
 
 #[doc(inline)]
-pub use core::{StdChild, StdChildWrapper, StdCommandWrap, StdCommandWrapper};
+pub use core::{StdChildWrapper, StdCommandWrap, StdCommandWrapper};
 #[cfg(all(windows, feature = "creation-flags"))]
 #[doc(inline)]
 pub use creation_flags::CreationFlags;

--- a/src/std/core.rs
+++ b/src/std/core.rs
@@ -229,13 +229,13 @@ impl StdChildWrapper for Child {
 		&mut self.stderr
 	}
 	fn id(&self) -> u32 {
-		self.id()
+		Child::id(self)
 	}
 	fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
-		self.try_wait()
+		Child::try_wait(self)
 	}
 	fn wait(&mut self) -> Result<ExitStatus> {
-		self.wait()
+		Child::wait(self)
 	}
 	#[cfg(unix)]
 	fn signal(&self, sig: i32) -> Result<()> {

--- a/src/std/core.rs
+++ b/src/std/core.rs
@@ -36,10 +36,9 @@ crate::generic_wrap::Wrap!(
 ///
 /// ```rust
 /// use process_wrap::std::*;
-/// use std::process::Child;
 ///
 /// #[derive(Debug)]
-/// pub struct YourChildWrapper(Child);
+/// pub struct YourChildWrapper(StdChild);
 ///
 /// impl StdChildWrapper for YourChildWrapper {
 ///     fn inner(&self) -> &dyn StdChildWrapper {

--- a/src/std/core.rs
+++ b/src/std/core.rs
@@ -127,15 +127,7 @@ pub trait StdChildWrapper: Any + std::fmt::Debug + Send {
 	/// library uses it to provide a consistent API across both std and Tokio (and because it's a
 	/// generally useful API).
 	fn start_kill(&mut self) -> Result<()> {
-		#[cfg(unix)]
-		{
-			self.signal(Signal::SIGKILL as _)
-		}
-
-		#[cfg(not(unix))]
-		{
-			self.inner_mut().kill()
-		}
+		self.inner_mut().start_kill()
 	}
 
 	/// Check if the `Child` has exited without blocking, and if so, return its exit status.
@@ -230,6 +222,17 @@ impl StdChildWrapper for Child {
 	}
 	fn id(&self) -> u32 {
 		Child::id(self)
+	}
+	fn start_kill(&mut self) -> Result<()> {
+		#[cfg(unix)]
+		{
+			self.signal(Signal::SIGKILL as _)
+		}
+
+		#[cfg(not(unix))]
+		{
+			Child::kill(self)
+		}
 	}
 	fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
 		Child::try_wait(self)

--- a/src/std/core.rs
+++ b/src/std/core.rs
@@ -205,11 +205,7 @@ pub trait StdChildWrapper: Any + std::fmt::Debug + Send {
 	/// and unwrapped processes.
 	#[cfg(unix)]
 	fn signal(&self, sig: i32) -> Result<()> {
-		kill(
-			Pid::from_raw(i32::try_from(self.id()).map_err(std::io::Error::other)?),
-			Signal::try_from(sig)?,
-		)
-		.map_err(std::io::Error::from)
+		self.inner().signal(sig)
 	}
 }
 
@@ -239,6 +235,23 @@ impl StdChildWrapper for StdChild {
 	}
 	fn stderr(&mut self) -> &mut Option<ChildStderr> {
 		&mut self.0.stderr
+	}
+	fn id(&self) -> u32 {
+		self.0.id()
+	}
+	fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+		self.0.try_wait()
+	}
+	fn wait(&mut self) -> Result<ExitStatus> {
+		self.0.wait()
+	}
+	#[cfg(unix)]
+	fn signal(&self, sig: i32) -> Result<()> {
+		kill(
+			Pid::from_raw(i32::try_from(self.id()).map_err(std::io::Error::other)?),
+			Signal::try_from(sig)?,
+		)
+		.map_err(std::io::Error::from)
 	}
 }
 

--- a/src/std/job_object.rs
+++ b/src/std/job_object.rs
@@ -135,13 +135,13 @@ impl StdChildWrapper for JobObjectChild {
 		let JobPort {
 			completion_port, ..
 		} = self.job_port;
-		wait_on_job(completion_port, None)?;
+		let _ = wait_on_job(completion_port, None)?;
 		Ok(status)
 	}
 
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
-		wait_on_job(self.job_port.completion_port, Some(Duration::ZERO))?;
+		let _ = wait_on_job(self.job_port.completion_port, Some(Duration::ZERO))?;
 		self.inner.try_wait()
 	}
 }

--- a/src/std/process_group.rs
+++ b/src/std/process_group.rs
@@ -2,7 +2,7 @@ use std::{
 	io::{Error, Result},
 	ops::ControlFlow,
 	os::unix::process::{CommandExt, ExitStatusExt},
-	process::{Child, Command, ExitStatus},
+	process::{Command, ExitStatus},
 };
 
 use nix::{
@@ -150,13 +150,13 @@ impl ProcessGroupChild {
 }
 
 impl StdChildWrapper for ProcessGroupChild {
-	fn inner(&self) -> &Child {
+	fn inner(&self) -> &dyn StdChildWrapper {
 		self.inner.inner()
 	}
-	fn inner_mut(&mut self) -> &mut Child {
+	fn inner_mut(&mut self) -> &mut dyn StdChildWrapper {
 		self.inner.inner_mut()
 	}
-	fn into_inner(self: Box<Self>) -> Child {
+	fn into_inner(self: Box<Self>) -> Box<dyn StdChildWrapper> {
 		self.inner.into_inner()
 	}
 
@@ -177,7 +177,7 @@ impl StdChildWrapper for ProcessGroupChild {
 		self.exit_status = ChildExitStatus::Exited(status);
 
 		// nevertheless, now wait and make sure we reap all children.
-		Self::wait_imp(self.pgid, WaitPidFlag::empty())?;
+		let _ = Self::wait_imp(self.pgid, WaitPidFlag::empty())?;
 		Ok(status)
 	}
 

--- a/src/tokio/core.rs
+++ b/src/tokio/core.rs
@@ -202,15 +202,7 @@ pub trait TokioChildWrapper: Any + std::fmt::Debug + Send {
 	/// and unwrapped processes.
 	#[cfg(unix)]
 	fn signal(&self, sig: i32) -> Result<()> {
-		if let Some(id) = self.id() {
-			kill(
-				Pid::from_raw(i32::try_from(id).map_err(std::io::Error::other)?),
-				Signal::try_from(sig)?,
-			)
-			.map_err(std::io::Error::from)
-		} else {
-			Ok(())
-		}
+		self.inner().signal(sig)
 	}
 }
 
@@ -232,6 +224,30 @@ impl TokioChildWrapper for Child {
 	}
 	fn stderr(&mut self) -> &mut Option<ChildStderr> {
 		&mut self.stderr
+	}
+	fn id(&self) -> Option<u32> {
+		self.id()
+	}
+	fn start_kill(&mut self) -> Result<()> {
+		self.start_kill()
+	}
+	fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+		self.try_wait()
+	}
+	fn wait(&mut self) -> Pin<Box<dyn Future<Output = Result<ExitStatus>> + Send + '_>> {
+		Box::pin(self.wait())
+	}
+	#[cfg(unix)]
+	fn signal(&self, sig: i32) -> Result<()> {
+		if let Some(id) = self.id() {
+			kill(
+				Pid::from_raw(i32::try_from(id).map_err(std::io::Error::other)?),
+				Signal::try_from(sig)?,
+			)
+			.map_err(std::io::Error::from)
+		} else {
+			Ok(())
+		}
 	}
 }
 

--- a/src/tokio/core.rs
+++ b/src/tokio/core.rs
@@ -24,7 +24,6 @@ crate::generic_wrap::Wrap!(
 	|child| child
 );
 
-crate::generic_wrap::MaybeAnyTrait! {
 /// Wrapper for `tokio::process::Child`.
 ///
 /// This trait exposes most of the functionality of the underlying [`Child`]. It is implemented for
@@ -212,7 +211,6 @@ pub trait TokioChildWrapper {
 			Ok(())
 		}
 	}
-}
 }
 
 impl TokioChildWrapper for Child {

--- a/src/tokio/core.rs
+++ b/src/tokio/core.rs
@@ -226,16 +226,16 @@ impl TokioChildWrapper for Child {
 		&mut self.stderr
 	}
 	fn id(&self) -> Option<u32> {
-		self.id()
+		Child::id(self)
 	}
 	fn start_kill(&mut self) -> Result<()> {
-		self.start_kill()
+		Child::start_kill(self)
 	}
 	fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
-		self.try_wait()
+		Child::try_wait(self)
 	}
 	fn wait(&mut self) -> Pin<Box<dyn Future<Output = Result<ExitStatus>> + Send + '_>> {
-		Box::pin(self.wait())
+		Box::pin(Child::wait(self))
 	}
 	#[cfg(unix)]
 	fn signal(&self, sig: i32) -> Result<()> {

--- a/src/tokio/core.rs
+++ b/src/tokio/core.rs
@@ -181,8 +181,7 @@ pub trait TokioChildWrapper: Any + std::fmt::Debug + Send {
 			let stdout_fut = read_to_end(&mut stdout_pipe);
 			let stderr_fut = read_to_end(&mut stderr_pipe);
 
-			let (status, stdout, stderr) =
-				try_join3(self.wait(), stdout_fut, stderr_fut).await?;
+			let (status, stdout, stderr) = try_join3(self.wait(), stdout_fut, stderr_fut).await?;
 
 			// Drop happens after `try_join` due to <https://github.com/tokio-rs/tokio/issues/4309>
 			drop(stdout_pipe);
@@ -238,8 +237,8 @@ impl TokioChildWrapper for Child {
 
 impl dyn TokioChildWrapper {
 	fn downcast_ref<T: 'static>(&self) -> Option<&T> {
-        (self as &dyn Any).downcast_ref()
-    }
+		(self as &dyn Any).downcast_ref()
+	}
 
 	fn is_raw_child(&self) -> bool {
 		self.downcast_ref::<Child>().is_some()

--- a/src/tokio/job_object.rs
+++ b/src/tokio/job_object.rs
@@ -161,14 +161,14 @@ impl TokioChildWrapper for JobObjectChild {
 			let JobPort {
 				completion_port, ..
 			} = self.job_port;
-			spawn_blocking(move || wait_on_job(completion_port, None)).await??;
+			let _ = spawn_blocking(move || wait_on_job(completion_port, None)).await??;
 			Ok(status)
 		})
 	}
 
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
-		wait_on_job(self.job_port.completion_port, Some(Duration::ZERO))?;
+		let _ = wait_on_job(self.job_port.completion_port, Some(Duration::ZERO))?;
 		self.inner.try_wait()
 	}
 }

--- a/src/tokio/job_object.rs
+++ b/src/tokio/job_object.rs
@@ -1,9 +1,6 @@
 use std::{future::Future, io::Result, pin::Pin, process::ExitStatus, time::Duration};
 
-use tokio::{
-	process::Command,
-	task::spawn_blocking,
-};
+use tokio::{process::Command, task::spawn_blocking};
 #[cfg(feature = "tracing")]
 use tracing::{debug, instrument};
 use windows::Win32::{

--- a/src/tokio/process_group.rs
+++ b/src/tokio/process_group.rs
@@ -3,6 +3,7 @@ use std::{
 	io::{Error, Result},
 	ops::ControlFlow,
 	os::unix::process::ExitStatusExt,
+	pin::Pin,
 	process::ExitStatus,
 };
 
@@ -15,10 +16,7 @@ use nix::{
 	},
 	unistd::Pid,
 };
-use tokio::{
-	process::{Child, Command},
-	task::spawn_blocking,
-};
+use tokio::{process::Command, task::spawn_blocking};
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
@@ -162,13 +160,13 @@ impl ProcessGroupChild {
 }
 
 impl TokioChildWrapper for ProcessGroupChild {
-	fn inner(&self) -> &Child {
+	fn inner(&self) -> &dyn TokioChildWrapper {
 		self.inner.inner()
 	}
-	fn inner_mut(&mut self) -> &mut Child {
+	fn inner_mut(&mut self) -> &mut dyn TokioChildWrapper {
 		self.inner.inner_mut()
 	}
-	fn into_inner(self: Box<Self>) -> Child {
+	fn into_inner(self: Box<Self>) -> Box<dyn TokioChildWrapper> {
 		self.inner.into_inner()
 	}
 
@@ -178,8 +176,8 @@ impl TokioChildWrapper for ProcessGroupChild {
 	}
 
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
-	fn wait(&mut self) -> Box<dyn Future<Output = Result<ExitStatus>> + Send + '_> {
-		Box::new(async {
+	fn wait(&mut self) -> Pin<Box<dyn Future<Output = Result<ExitStatus>> + Send + '_>> {
+		Box::pin(async {
 			if let ChildExitStatus::Exited(status) = &self.exit_status {
 				return Ok(*status);
 			}
@@ -189,7 +187,7 @@ impl TokioChildWrapper for ProcessGroupChild {
 
 			// always wait for parent to exit first, as by the time it does,
 			// it's likely that all its children have already been reaped.
-			let status = Box::into_pin(self.inner.wait()).await?;
+			let status = self.inner.wait().await?;
 			self.exit_status = ChildExitStatus::Exited(status);
 
 			// nevertheless, now try reaping all children a few times...

--- a/src/tokio/process_group.rs
+++ b/src/tokio/process_group.rs
@@ -201,7 +201,7 @@ impl TokioChildWrapper for ProcessGroupChild {
 
 			// ...finally, if there are some that are still alive,
 			// block in the background to reap them fully.
-			spawn_blocking(move || Self::wait_imp(pgid, WaitPidFlag::empty())).await??;
+			let _ = spawn_blocking(move || Self::wait_imp(pgid, WaitPidFlag::empty())).await??;
 			Ok(status)
 		})
 	}

--- a/tests/std_unix/into_inner_write_stdin.rs
+++ b/tests/std_unix/into_inner_write_stdin.rs
@@ -2,11 +2,13 @@ use super::prelude::*;
 
 #[test]
 fn nowrap() -> Result<()> {
-	let mut child = StdCommandWrap::with_new("cat", |command| {
-		command.stdin(Stdio::piped()).stdout(Stdio::piped());
-	})
-	.spawn()?
-	.into_inner();
+	let mut child = unsafe {
+		StdCommandWrap::with_new("cat", |command| {
+			command.stdin(Stdio::piped()).stdout(Stdio::piped());
+		})
+		.spawn()?
+		.into_inner_child()
+	};
 
 	if let Some(mut din) = child.stdin.take() {
 		din.write_all(b"hello")?;
@@ -23,12 +25,14 @@ fn nowrap() -> Result<()> {
 
 #[test]
 fn process_group() -> Result<()> {
-	let mut child = StdCommandWrap::with_new("cat", |command| {
-		command.stdin(Stdio::piped()).stdout(Stdio::piped());
-	})
-	.wrap(ProcessGroup::leader())
-	.spawn()?
-	.into_inner();
+	let mut child = unsafe {
+		StdCommandWrap::with_new("cat", |command| {
+			command.stdin(Stdio::piped()).stdout(Stdio::piped());
+		})
+		.wrap(ProcessGroup::leader())
+		.spawn()?
+		.into_inner_child()
+	};
 
 	if let Some(mut din) = child.stdin.take() {
 		din.write_all(b"hello")?;
@@ -45,12 +49,14 @@ fn process_group() -> Result<()> {
 
 #[test]
 fn process_session() -> Result<()> {
-	let mut child = StdCommandWrap::with_new("cat", |command| {
-		command.stdin(Stdio::piped()).stdout(Stdio::piped());
-	})
-	.wrap(ProcessSession)
-	.spawn()?
-	.into_inner();
+	let mut child = unsafe {
+		StdCommandWrap::with_new("cat", |command| {
+			command.stdin(Stdio::piped()).stdout(Stdio::piped());
+		})
+		.wrap(ProcessSession)
+		.spawn()?
+		.into_inner_child()
+	};
 
 	if let Some(mut din) = child.stdin.take() {
 		din.write_all(b"hello")?;

--- a/tests/std_windows/into_inner_write_stdin.rs
+++ b/tests/std_windows/into_inner_write_stdin.rs
@@ -11,12 +11,12 @@ fn nowrap() -> Result<()> {
 	.spawn()?
 	.into_inner();
 
-	if let Some(mut din) = child.stdin.take() {
+	if let Some(mut din) = child.stdin().take() {
 		din.write_all(b"hello")?;
 	}
 
 	let mut output = String::new();
-	if let Some(mut out) = child.stdout.take() {
+	if let Some(mut out) = child.stdout().take() {
 		out.read_to_string(&mut output)?;
 	}
 
@@ -36,12 +36,12 @@ fn job_object() -> Result<()> {
 	.spawn()?
 	.into_inner();
 
-	if let Some(mut din) = child.stdin.take() {
+	if let Some(mut din) = child.stdin().take() {
 		din.write_all(b"hello")?;
 	}
 
 	let mut output = String::new();
-	if let Some(mut out) = child.stdout.take() {
+	if let Some(mut out) = child.stdout().take() {
 		out.read_to_string(&mut output)?;
 	}
 

--- a/tests/std_windows/kill_and_try_wait.rs
+++ b/tests/std_windows/kill_and_try_wait.rs
@@ -8,7 +8,7 @@ fn nowrap() -> Result<()> {
 	.spawn()?;
 	assert!(child.try_wait()?.is_none(), "pre kill");
 
-	(child.kill())?;
+	child.kill()?;
 	sleep(DIE_TIME);
 	assert!(child.try_wait()?.is_some(), "try_wait() one");
 
@@ -27,7 +27,7 @@ fn job_object() -> Result<()> {
 	.spawn()?;
 	assert!(child.try_wait()?.is_none(), "pre kill");
 
-	(child.kill())?;
+	child.kill()?;
 	sleep(DIE_TIME);
 	assert!(child.try_wait()?.is_some(), "try_wait() one");
 

--- a/tests/tokio_unix/kill_and_try_wait.rs
+++ b/tests/tokio_unix/kill_and_try_wait.rs
@@ -29,7 +29,7 @@ async fn process_group() -> Result<()> {
 
 	Box::into_pin(child.kill()).await?;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(!status.success());
 
 	sleep(DIE_TIME).await;

--- a/tests/tokio_unix/multiproc_linux.rs
+++ b/tests/tokio_unix/multiproc_linux.rs
@@ -83,7 +83,7 @@ async fn process_group_kill_group() -> Result<()> {
 	nix::sys::signal::killpg(nix::unistd::Pid::from_raw(parent), Signal::SIGKILL).unwrap();
 	sleep(DIE_TIME).await;
 	assert!(!pid_alive(child), "child process should be dead");
-	Box::into_pin(leader.wait()).await.unwrap();
+	leader.wait().await.unwrap();
 	assert!(!pid_alive(parent), "parent process should be dead");
 
 	Ok(())
@@ -170,7 +170,7 @@ async fn process_session_kill_group() -> Result<()> {
 	nix::sys::signal::killpg(nix::unistd::Pid::from_raw(parent), Signal::SIGKILL).unwrap();
 	sleep(DIE_TIME).await;
 	assert!(!pid_alive(child), "child process should be dead");
-	Box::into_pin(leader.wait()).await.unwrap();
+	leader.wait().await.unwrap();
 	assert!(!pid_alive(parent), "parent process should be dead");
 
 	Ok(())

--- a/tests/tokio_unix/wait_after_die.rs
+++ b/tests/tokio_unix/wait_after_die.rs
@@ -8,7 +8,7 @@ async fn nowrap() -> Result<()> {
 	.spawn()?;
 	sleep(DIE_TIME).await;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
 	Ok(())
@@ -23,7 +23,7 @@ async fn process_group() -> Result<()> {
 	.spawn()?;
 	sleep(DIE_TIME).await;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
 	Ok(())
@@ -38,7 +38,7 @@ async fn process_session() -> Result<()> {
 	.spawn()?;
 	sleep(DIE_TIME).await;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
 	Ok(())

--- a/tests/tokio_unix/wait_twice.rs
+++ b/tests/tokio_unix/wait_twice.rs
@@ -7,10 +7,10 @@ async fn nowrap() -> Result<()> {
 	})
 	.spawn()?;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
 	Ok(())
@@ -24,10 +24,10 @@ async fn process_group() -> Result<()> {
 	.wrap(ProcessGroup::leader())
 	.spawn()?;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
 	Ok(())
@@ -41,10 +41,10 @@ async fn process_session() -> Result<()> {
 	.wrap(ProcessSession)
 	.spawn()?;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
 	Ok(())

--- a/tests/tokio_unix/wait_twice_after_sigterm.rs
+++ b/tests/tokio_unix/wait_twice_after_sigterm.rs
@@ -10,10 +10,10 @@ async fn nowrap() -> Result<()> {
 
 	child.signal(Signal::SIGTERM as _)?;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert_eq!(status.signal(), Some(Signal::SIGTERM as i32), "wait() one");
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert_eq!(status.signal(), Some(Signal::SIGTERM as i32), "wait() two");
 
 	Ok(())
@@ -30,10 +30,10 @@ async fn process_group() -> Result<()> {
 
 	child.signal(Signal::SIGTERM as _)?;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert_eq!(status.signal(), Some(Signal::SIGTERM as i32), "wait() one");
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert_eq!(status.signal(), Some(Signal::SIGTERM as i32), "wait() two");
 
 	Ok(())
@@ -50,10 +50,10 @@ async fn process_session() -> Result<()> {
 
 	child.signal(Signal::SIGTERM as _)?;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert_eq!(status.signal(), Some(Signal::SIGTERM as i32), "wait() one");
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert_eq!(status.signal(), Some(Signal::SIGTERM as i32), "wait() two");
 
 	Ok(())

--- a/tests/tokio_windows/wait_after_die.rs
+++ b/tests/tokio_windows/wait_after_die.rs
@@ -8,7 +8,7 @@ async fn nowrap() -> Result<()> {
 	.spawn()?;
 	sleep(DIE_TIME).await;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
 	Ok(())
@@ -23,7 +23,7 @@ async fn job_object() -> Result<()> {
 	.spawn()?;
 	sleep(DIE_TIME).await;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
 	Ok(())

--- a/tests/tokio_windows/wait_twice.rs
+++ b/tests/tokio_windows/wait_twice.rs
@@ -7,10 +7,10 @@ async fn nowrap() -> Result<()> {
 	})
 	.spawn()?;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
 	Ok(())
@@ -24,10 +24,10 @@ async fn job_object() -> Result<()> {
 	.wrap(JobObject)
 	.spawn()?;
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
-	let status = Box::into_pin(child.wait()).await?;
+	let status = child.wait().await?;
 	assert!(status.success());
 
 	Ok(())


### PR DESCRIPTION
Implementation for #22

Migration for tokio: replace `Box::into_pin(child.wait())` with `child.wait()`