### PR TITLE
docs: fix incorrect `JobObject::new()` usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ use tokio::process::Command;
 use process_wrap::tokio::*;
 
 let mut child = TokioCommandWrap::with_new("watch", |command| { command.arg("ls"); })
-  .wrap(JobObject::new())
+  .wrap(JobObject)
   .spawn()?;
 let status = Box::into_pin(child.wait()).await?;
 dbg!(status);
@@ -140,7 +140,7 @@ TokioCommandWrap::with_new("watch", |command| { command.arg("ls"); })
   .spawn()?;
 ```
 
-For Windows process groups, use `CreationFlags::NEW_PROCESS_GROUP` and/or `JobObject::new()`.
+For Windows process groups, use `CreationFlags::NEW_PROCESS_GROUP` and/or `JobObject`.
 
 ### Process session
 


### PR DESCRIPTION
 ## Summary
  - `JobObject` is a unit struct (`pub struct JobObject;`) with no `new()` method
  - README had two places still using the old `JobObject::new()` syntax:
    - Quick start Windows example (line 54)
    - Process group section text (line 143)
  - Updated both to `JobObject`, consistent with the rest of the README

  ## Context
  The other README examples (Job object section, Creation flags section) already
  correctly use `.wrap(JobObject)`. These two were likely leftover from an earlier
  API that has since been simplified.
