### PR TITLE
fix!: make stored wrapper operations type-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ impl CommandWrapper for YourWrapper {}
 That's right, all member methods are optional.
 The trait provides extension or hook points into the lifecycle of a `Command`:
 
-- **`fn extend(&mut self, other: Box<dyn CommandWrapper>)`** is called if `.wrap(YourWrapper)`
-  is done twice. Only one of a wrapper type can exist, so this gives the opportunity to incorporate
-  all or part of the second wrapper instance into the first. By default, this does nothing (ie only
-  the first registered wrapper instance of a type does anything).
+- **`fn extend(&mut self, other: Self)`** is called if `.wrap(YourWrapper)` is done twice.
+  Only one wrapper of a given type can exist, so this gives the stored instance an opportunity to
+  incorporate all or part of the second, concretely typed wrapper. By default, this does nothing
+  (that is, only the first registered wrapper instance of a type applies).
 
 - **`fn pre_spawn(&mut self, command: &mut Command, core: &CommandWrap)`** is called before the
   command is spawned, and gives mutable access to it. It also gives mutable access to the wrapper

--- a/src/generic_wrap.rs
+++ b/src/generic_wrap.rs
@@ -5,6 +5,21 @@
 
 macro_rules! Wrap {
 	($command:ty, $child:ty, $childer:ident, $first_child_wrapper:expr) => {
+		trait ErasedCommandWrapper: ::std::fmt::Debug + Send + Sync {
+			fn as_command_wrapper_mut(&mut self) -> &mut dyn CommandWrapper;
+			fn as_any(&self) -> &dyn ::std::any::Any;
+		}
+
+		impl<W: CommandWrapper + 'static> ErasedCommandWrapper for W {
+			fn as_command_wrapper_mut(&mut self) -> &mut dyn CommandWrapper {
+				self
+			}
+
+			fn as_any(&self) -> &dyn ::std::any::Any {
+				self
+			}
+		}
+
 		/// A wrapper around a `Command` that allows for additional functionality to be added.
 		///
 		/// This is the core type of the `process-wrap` crate. It is a wrapper around a
@@ -12,7 +27,10 @@ macro_rules! Wrap {
 		#[derive(Debug)]
 		pub struct CommandWrap {
 			command: $command,
-			wrappers: ::indexmap::IndexMap<::std::any::TypeId, Box<dyn CommandWrapper>>,
+			wrappers: ::indexmap::IndexMap<
+				::std::any::TypeId,
+				Box<dyn ErasedCommandWrapper>,
+			>,
 		}
 
 		impl CommandWrap {
@@ -62,13 +80,14 @@ macro_rules! Wrap {
 			/// Returns `&mut self` for chaining.
 			pub fn wrap<W: CommandWrapper + 'static>(&mut self, wrapper: W) -> &mut Self {
 				let typeid = ::std::any::TypeId::of::<W>();
-				let mut wrapper = Some(Box::new(wrapper));
-				let extant = self
-					.wrappers
-					.entry(typeid)
-					.or_insert_with(|| wrapper.take().unwrap());
+				let mut wrapper = Some(wrapper);
+				let extant = self.wrappers.entry(typeid).or_insert_with(|| {
+					Box::new(wrapper.take().unwrap()) as Box<dyn ErasedCommandWrapper>
+				});
 				if let Some(wrapper) = wrapper {
-					extant.extend(wrapper);
+					extant
+						.as_command_wrapper_mut()
+						.extend(Box::new(wrapper));
 				}
 
 				self
@@ -79,20 +98,27 @@ macro_rules! Wrap {
 			fn spawn_inner(
 				&self,
 				command: &mut $command,
-				wrappers: &mut ::indexmap::IndexMap<::std::any::TypeId, Box<dyn CommandWrapper>>,
+				wrappers: &mut ::indexmap::IndexMap<
+					::std::any::TypeId,
+					Box<dyn ErasedCommandWrapper>,
+				>,
 				spawner: impl FnOnce(&mut $command) -> ::std::io::Result<$child>,
 			) -> ::std::io::Result<Box<dyn $childer>> {
-				for (id, wrapper) in wrappers.iter_mut() {
+				for (_id, wrapper) in wrappers.iter_mut() {
 					#[cfg(feature = "tracing")]
-					::tracing::debug!(?id, "pre_spawn");
-					wrapper.pre_spawn(command, self)?;
+					::tracing::debug!(id = ?_id, "pre_spawn");
+					wrapper
+						.as_command_wrapper_mut()
+						.pre_spawn(command, self)?;
 				}
 
 				let mut child = spawner(command)?;
-				for (id, wrapper) in wrappers.iter_mut() {
+				for (_id, wrapper) in wrappers.iter_mut() {
 					#[cfg(feature = "tracing")]
-					::tracing::debug!(?id, "post_spawn");
-					wrapper.post_spawn(command, &mut child, self)?;
+					::tracing::debug!(id = ?_id, "post_spawn");
+					wrapper
+						.as_command_wrapper_mut()
+						.post_spawn(command, &mut child, self)?;
 				}
 
 				let mut child = Box::new(
@@ -100,10 +126,12 @@ macro_rules! Wrap {
 					$first_child_wrapper(child),
 				) as Box<dyn $childer>;
 
-				for (id, wrapper) in wrappers.iter_mut() {
+				for (_id, wrapper) in wrappers.iter_mut() {
 					#[cfg(feature = "tracing")]
-					::tracing::debug!(?id, "wrap_child");
-					child = wrapper.wrap_child(child, self)?;
+					::tracing::debug!(id = ?_id, "wrap_child");
+					child = wrapper
+						.as_command_wrapper_mut()
+						.wrap_child(child, self)?;
 				}
 
 				Ok(child)
@@ -157,11 +185,11 @@ macro_rules! Wrap {
 			/// present, use `has_wrap` instead.
 			pub fn get_wrap<W: CommandWrapper + 'static>(&self) -> Option<&W> {
 				let typeid = ::std::any::TypeId::of::<W>();
-				self.wrappers.get(&typeid).map(|w| {
-					let w_any = w as &dyn ::std::any::Any;
-					w_any
+				self.wrappers.get(&typeid).map(|wrapper| {
+					wrapper
+						.as_any()
 						.downcast_ref()
-						.expect("downcasting is guaranteed to succeed due to wrap()'s internals")
+						.expect("the wrapper key and concrete type must match")
 				})
 			}
 		}

--- a/src/generic_wrap.rs
+++ b/src/generic_wrap.rs
@@ -8,6 +8,7 @@ macro_rules! Wrap {
 		trait ErasedCommandWrapper: ::std::fmt::Debug + Send + Sync {
 			fn as_command_wrapper_mut(&mut self) -> &mut dyn CommandWrapper;
 			fn as_any(&self) -> &dyn ::std::any::Any;
+			fn as_any_mut(&mut self) -> &mut dyn ::std::any::Any;
 		}
 
 		impl<W: CommandWrapper + 'static> ErasedCommandWrapper for W {
@@ -16,6 +17,10 @@ macro_rules! Wrap {
 			}
 
 			fn as_any(&self) -> &dyn ::std::any::Any {
+				self
+			}
+
+			fn as_any_mut(&mut self) -> &mut dyn ::std::any::Any {
 				self
 			}
 		}
@@ -86,8 +91,10 @@ macro_rules! Wrap {
 				});
 				if let Some(wrapper) = wrapper {
 					extant
-						.as_command_wrapper_mut()
-						.extend(Box::new(wrapper));
+						.as_any_mut()
+						.downcast_mut::<W>()
+						.expect("downcasting is guaranteed to succeed due to wrap()'s internals")
+						.extend(wrapper);
 				}
 
 				self
@@ -189,7 +196,7 @@ macro_rules! Wrap {
 					wrapper
 						.as_any()
 						.downcast_ref()
-						.expect("the wrapper key and concrete type must match")
+						.expect("downcasting is guaranteed to succeed due to wrap()'s internals")
 				})
 			}
 		}
@@ -217,18 +224,20 @@ macro_rules! Wrap {
 		pub trait CommandWrapper: ::std::fmt::Debug + Send + Sync {
 			/// Called on a first instance if a second of the same type is added.
 			///
-			/// Only one of a wrapper type can exist within a Wrap at a time. The default behaviour
-			/// is to silently discard any further invocations. However in some cases it might be
-			/// useful to merge the two. This method is called on the instance already stored within
-			/// the Wrap, with the new instance.
+			/// Only one wrapper of a given type can exist within a Wrap at a time. By default,
+			/// later registrations are discarded. In some cases it is useful to merge their
+			/// configuration instead. This method is called on the stored wrapper with the newly
+			/// registered wrapper of the same concrete type.
 			///
-			/// The `other` argument is guaranteed by process-wrap to be of the same type as `self`,
-			/// so you can downcast it with `.unwrap()` and not panic. Note that it is possible for
-			/// other code to use this trait and not guarantee this, so you should still panic if
-			/// downcasting fails, instead of using unchecked downcasting and unleashing UB.
+			/// Because `other` is `Self`, implementations can inspect or move its type-specific
+			/// fields directly without downcasting.
 			///
 			/// Default impl: no-op.
-			fn extend(&mut self, _other: Box<dyn CommandWrapper>) {}
+			fn extend(&mut self, _other: Self)
+			where
+				Self: Sized,
+			{
+			}
 
 			/// Called before the command is spawned, to mutate it as needed.
 			///

--- a/src/generic_wrap.rs
+++ b/src/generic_wrap.rs
@@ -78,9 +78,9 @@ macro_rules! Wrap {
 			/// called.
 			///
 			/// Only one wrapper of a given type can be applied to a command. If `wrap` is called
-			/// twice with the same type, the existing wrapper will have its `extend` hook called,
-			/// which gives it a chance to absorb the new wrapper. If it does not, the _new_ wrapper
-			/// will be silently discarded.
+			/// twice with the same type, the existing wrapper receives the newly registered wrapper
+			/// through its typed `extend` hook and can merge its configuration. If the hook does
+			/// nothing, the _new_ wrapper is silently discarded.
 			///
 			/// Returns `&mut self` for chaining.
 			pub fn wrap<W: CommandWrapper + 'static>(&mut self, wrapper: W) -> &mut Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,10 +126,10 @@
 //!
 //! The trait provides extension or hook points into the lifecycle of a `Command`:
 //!
-//! - **`fn extend(&mut self, other: Box<dyn CommandWrapper>)`** is called if
-//!   `.wrap(YourWrapper)` is done twice. Only one of a wrapper type can exist, so this gives the
-//!   opportunity to incorporate all or part of the second wrapper instance into the first. By
-//!   default, this does nothing (ie only the first registered wrapper instance of a type applies).
+//! - **`fn extend(&mut self, other: Self)`** is called if `.wrap(YourWrapper)` is done twice.
+//!   Only one wrapper of a given type can exist, so this gives the stored instance an opportunity to
+//!   incorporate all or part of the second, concretely typed wrapper. By default, this does nothing
+//!   (that is, only the first registered wrapper instance of a type applies).
 //!
 //! - **`fn pre_spawn(&mut self, command: &mut Command, core: &CommandWrap)`** is called before
 //!   the command is spawned, and gives mutable access to it. It also gives mutable access to the

--- a/tests/std_windows/try_wait_after_die.rs
+++ b/tests/std_windows/try_wait_after_die.rs
@@ -1,42 +1,39 @@
 use super::prelude::*;
 
+fn assert_exits(child: &mut dyn ChildWrapper) -> Result<()> {
+	let deadline = std::time::Instant::now() + Duration::from_secs(5);
+	loop {
+		if let Some(status) = child.try_wait()? {
+			assert!(status.success());
+			return Ok(());
+		}
+		if std::time::Instant::now() >= deadline {
+			child.kill()?;
+			return Err(std::io::Error::new(
+				std::io::ErrorKind::TimedOut,
+				"command did not exit before try_wait deadline",
+			));
+		}
+		sleep(Duration::from_millis(10));
+	}
+}
+
+fn command() -> CommandWrap {
+	CommandWrap::with_new("cmd.exe", |command| {
+		command
+			.args(["/D", "/S", "/C", "exit /b 0"])
+			.stdout(Stdio::null());
+	})
+}
+
 #[test]
 fn nowrap() -> Result<()> {
-	let mut child = CommandWrap::with_new("powershell.exe", |command| {
-		command.arg("/C").arg("echo hello").stdout(Stdio::null());
-	})
-	.spawn()?;
-	let mut status = None;
-	for _ in 0..200 {
-		status = child.try_wait()?;
-		if status.is_some() {
-			break;
-		}
-		sleep(Duration::from_millis(50));
-	}
-	assert!(status.is_some());
-	assert!(status.unwrap().success());
-
-	Ok(())
+	let mut child = command().spawn()?;
+	assert_exits(child.as_mut())
 }
 
 #[test]
 fn job_object() -> Result<()> {
-	let mut child = CommandWrap::with_new("powershell.exe", |command| {
-		command.arg("/C").arg("echo hello").stdout(Stdio::null());
-	})
-	.wrap(JobObject)
-	.spawn()?;
-	let mut status = None;
-	for _ in 0..200 {
-		status = child.try_wait()?;
-		if status.is_some() {
-			break;
-		}
-		sleep(Duration::from_millis(50));
-	}
-	assert!(status.is_some());
-	assert!(status.unwrap().success());
-
-	Ok(())
+	let mut child = command().wrap(JobObject).spawn()?;
+	assert_exits(child.as_mut())
 }

--- a/tests/std_windows/try_wait_after_die.rs
+++ b/tests/std_windows/try_wait_after_die.rs
@@ -6,8 +6,14 @@ fn nowrap() -> Result<()> {
 		command.arg("/C").arg("echo hello").stdout(Stdio::null());
 	})
 	.spawn()?;
-	sleep(DIE_TIME);
-	let status = child.try_wait()?;
+	let mut status = None;
+	for _ in 0..200 {
+		status = child.try_wait()?;
+		if status.is_some() {
+			break;
+		}
+		sleep(Duration::from_millis(50));
+	}
 	assert!(status.is_some());
 	assert!(status.unwrap().success());
 
@@ -21,8 +27,14 @@ fn job_object() -> Result<()> {
 	})
 	.wrap(JobObject)
 	.spawn()?;
-	sleep(DIE_TIME);
-	let status = child.try_wait()?;
+	let mut status = None;
+	for _ in 0..200 {
+		status = child.try_wait()?;
+		if status.is_some() {
+			break;
+		}
+		sleep(Duration::from_millis(50));
+	}
 	assert!(status.is_some());
 	assert!(status.unwrap().success());
 

--- a/tests/tokio_windows/try_wait_after_die.rs
+++ b/tests/tokio_windows/try_wait_after_die.rs
@@ -1,42 +1,39 @@
 use super::prelude::*;
 
+async fn assert_exits(child: &mut dyn ChildWrapper) -> Result<()> {
+	let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+	loop {
+		if let Some(status) = child.try_wait()? {
+			assert!(status.success());
+			return Ok(());
+		}
+		if tokio::time::Instant::now() >= deadline {
+			child.start_kill()?;
+			return Err(std::io::Error::new(
+				std::io::ErrorKind::TimedOut,
+				"command did not exit before try_wait deadline",
+			));
+		}
+		sleep(Duration::from_millis(10)).await;
+	}
+}
+
+fn command() -> CommandWrap {
+	CommandWrap::with_new("cmd.exe", |command| {
+		command
+			.args(["/D", "/S", "/C", "exit /b 0"])
+			.stdout(Stdio::null());
+	})
+}
+
 #[tokio::test]
 async fn nowrap() -> Result<()> {
-	let mut child = CommandWrap::with_new("powershell.exe", |command| {
-		command.arg("/C").arg("echo hello").stdout(Stdio::null());
-	})
-	.spawn()?;
-	let mut status = None;
-	for _ in 0..200 {
-		status = child.try_wait()?;
-		if status.is_some() {
-			break;
-		}
-		sleep(Duration::from_millis(50)).await;
-	}
-	assert!(status.is_some());
-	assert!(status.unwrap().success());
-
-	Ok(())
+	let mut child = command().spawn()?;
+	assert_exits(child.as_mut()).await
 }
 
 #[tokio::test]
 async fn job_object() -> Result<()> {
-	let mut child = CommandWrap::with_new("powershell.exe", |command| {
-		command.arg("/C").arg("echo hello").stdout(Stdio::null());
-	})
-	.wrap(JobObject)
-	.spawn()?;
-	let mut status = None;
-	for _ in 0..200 {
-		status = child.try_wait()?;
-		if status.is_some() {
-			break;
-		}
-		sleep(Duration::from_millis(50)).await;
-	}
-	assert!(status.is_some());
-	assert!(status.unwrap().success());
-
-	Ok(())
+	let mut child = command().wrap(JobObject).spawn()?;
+	assert_exits(child.as_mut()).await
 }

--- a/tests/tokio_windows/try_wait_after_die.rs
+++ b/tests/tokio_windows/try_wait_after_die.rs
@@ -6,8 +6,14 @@ async fn nowrap() -> Result<()> {
 		command.arg("/C").arg("echo hello").stdout(Stdio::null());
 	})
 	.spawn()?;
-	sleep(DIE_TIME).await;
-	let status = child.try_wait()?;
+	let mut status = None;
+	for _ in 0..200 {
+		status = child.try_wait()?;
+		if status.is_some() {
+			break;
+		}
+		sleep(Duration::from_millis(50)).await;
+	}
 	assert!(status.is_some());
 	assert!(status.unwrap().success());
 
@@ -21,8 +27,14 @@ async fn job_object() -> Result<()> {
 	})
 	.wrap(JobObject)
 	.spawn()?;
-	sleep(DIE_TIME).await;
-	let status = child.try_wait()?;
+	let mut status = None;
+	for _ in 0..200 {
+		status = child.try_wait()?;
+		if status.is_some() {
+			break;
+		}
+		sleep(Duration::from_millis(50)).await;
+	}
 	assert!(status.is_some());
 	assert!(status.unwrap().success());
 

--- a/tests/wrapper_lookup.rs
+++ b/tests/wrapper_lookup.rs
@@ -11,8 +11,9 @@ macro_rules! wrapper_lookup_tests {
 			}
 
 			impl CommandWrapper for LookupWrapper {
-				fn extend(&mut self, _other: Box<dyn CommandWrapper>) {
-					self.extensions += 1;
+				fn extend(&mut self, other: Self) {
+					self.value += other.value;
+					self.extensions += other.extensions + 1;
 				}
 			}
 
@@ -55,14 +56,14 @@ macro_rules! wrapper_lookup_tests {
 					})
 					.wrap(LookupWrapper {
 						value: 2,
-						extensions: 0,
+						extensions: 3,
 					});
 
 				let wrapper = command
 					.get_wrap::<LookupWrapper>()
 					.expect("the first wrapper remains registered");
-				assert_eq!(wrapper.value, 1);
-				assert_eq!(wrapper.extensions, 1);
+				assert_eq!(wrapper.value, 3);
+				assert_eq!(wrapper.extensions, 4);
 			}
 
 			#[test]

--- a/tests/wrapper_lookup.rs
+++ b/tests/wrapper_lookup.rs
@@ -1,0 +1,89 @@
+macro_rules! wrapper_lookup_tests {
+	($module:ident, $command_wrap:path, $command_wrapper:path) => {
+		mod $module {
+			use $command_wrap as CommandWrap;
+			use $command_wrapper as CommandWrapper;
+
+			#[derive(Debug)]
+			struct LookupWrapper {
+				value: usize,
+				extensions: usize,
+			}
+
+			impl CommandWrapper for LookupWrapper {
+				fn extend(&mut self, _other: Box<dyn CommandWrapper>) {
+					self.extensions += 1;
+				}
+			}
+
+			#[derive(Debug)]
+			struct MissingWrapper;
+
+			impl CommandWrapper for MissingWrapper {}
+
+			fn command() -> CommandWrap {
+				CommandWrap::with_new("", |_| {})
+			}
+
+			#[test]
+			fn gets_stored_wrapper_by_concrete_type() {
+				let mut command = command();
+				assert!(!command.has_wrap::<LookupWrapper>());
+				assert!(command.get_wrap::<LookupWrapper>().is_none());
+				assert!(command.get_wrap::<MissingWrapper>().is_none());
+
+				command.wrap(LookupWrapper {
+					value: 42,
+					extensions: 0,
+				});
+
+				assert!(command.has_wrap::<LookupWrapper>());
+				let wrapper = command
+					.get_wrap::<LookupWrapper>()
+					.expect("the wrapper was just registered");
+				assert_eq!(wrapper.value, 42);
+				assert_eq!(wrapper.extensions, 0);
+			}
+
+			#[test]
+			fn duplicate_type_extends_the_stored_wrapper() {
+				let mut command = command();
+				command
+					.wrap(LookupWrapper {
+						value: 1,
+						extensions: 0,
+					})
+					.wrap(LookupWrapper {
+						value: 2,
+						extensions: 0,
+					});
+
+				let wrapper = command
+					.get_wrap::<LookupWrapper>()
+					.expect("the first wrapper remains registered");
+				assert_eq!(wrapper.value, 1);
+				assert_eq!(wrapper.extensions, 1);
+			}
+
+			#[test]
+			fn command_wrap_is_sync() {
+				fn assert_sync<T: Sync>() {}
+				assert_sync::<CommandWrap>();
+			}
+		}
+	};
+}
+
+#[cfg(feature = "std")]
+wrapper_lookup_tests!(
+	std_frontend,
+	process_wrap::std::CommandWrap,
+	process_wrap::std::CommandWrapper
+);
+
+#[cfg(feature = "tokio1")]
+wrapper_lookup_tests!(
+	tokio_frontend,
+	process_wrap::tokio::CommandWrap,
+	process_wrap::tokio::CommandWrapper
+);


### PR DESCRIPTION
`get_wrap` just plain did not work, and neither did `extend`, as it erased the very type implementations would want to merge.

- add a private erased-wrapper adapter that exposes the stored concrete wrapper for checked internal downcasting
- make `get_wrap::<W>()` downcast the registered wrapper value rather than its outer box
- change `CommandWrapper::extend` to receive the newly registered wrapper as concrete `Self`
- keep `CommandWrapper` object-safe with a `Self: Sized` bound and no public `Any` supertrait
- cover concrete lookup, typed configuration merging, duplicate registration, and `Sync` for both frontends

This deliberately breaks the API: `extend(&mut self, Box<dyn CommandWrapper>)` never could work.

This is the first part of #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
