### PR TITLE
fix: preserve live wrapper composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ CommandWrap::with_new("watch", |command| { command.arg("ls"); })
   .spawn()?;
 ```
 
-When both `CreationFlags` and `JobObject` are used together, either:
-- `CreationFlags` must come first, or
-- `CreationFlags` must include `CREATE_SUSPENDED`
+`CreationFlags` and `JobObject` may be registered in either order. `JobObject` preserves every
+requested flag, temporarily adds `CREATE_SUSPENDED` while assigning the process, and resumes it
+after assignment unless the caller explicitly requested `CREATE_SUSPENDED`.
 
 ### Process group
 
@@ -183,9 +183,9 @@ CommandWrap::with_new("watch", |command| { command.arg("ls"); })
   .spawn()?;
 ```
 
-When both `CreationFlags` and `JobObject` are used together, either:
-- `CreationFlags` must come first, or
-- `CreationFlags` must include `CREATE_SUSPENDED`
+`CreationFlags` and `JobObject` may be registered in either order. `JobObject` preserves every
+requested flag, temporarily adds `CREATE_SUSPENDED` while assigning the process, and resumes it
+after assignment unless the caller explicitly requested `CREATE_SUSPENDED`.
 
 ### Kill on drop
 

--- a/src/generic_wrap.rs
+++ b/src/generic_wrap.rs
@@ -29,7 +29,7 @@ macro_rules! Wrap {
 			command: $command,
 			wrappers: ::indexmap::IndexMap<
 				::std::any::TypeId,
-				Box<dyn ErasedCommandWrapper>,
+				Option<Box<dyn ErasedCommandWrapper>>,
 			>,
 		}
 
@@ -82,10 +82,12 @@ macro_rules! Wrap {
 				let typeid = ::std::any::TypeId::of::<W>();
 				let mut wrapper = Some(wrapper);
 				let extant = self.wrappers.entry(typeid).or_insert_with(|| {
-					Box::new(wrapper.take().unwrap()) as Box<dyn ErasedCommandWrapper>
+					Some(Box::new(wrapper.take().unwrap()) as Box<dyn ErasedCommandWrapper>)
 				});
 				if let Some(wrapper) = wrapper {
 					extant
+						.as_mut()
+						.expect("a wrapper cannot be replaced while its hook is active")
 						.as_command_wrapper_mut()
 						.extend(Box::new(wrapper));
 				}
@@ -93,32 +95,68 @@ macro_rules! Wrap {
 				self
 			}
 
-			// poor man's try..finally block
+			#[inline]
+			fn with_wrapper_at<T>(
+				&mut self,
+				index: usize,
+				invoke: impl FnOnce(
+					&mut dyn CommandWrapper,
+					&CommandWrap,
+				) -> ::std::io::Result<T>,
+			) -> ::std::io::Result<T> {
+				let mut wrapper = self
+					.wrappers
+					.get_index_mut(index)
+					.expect("the wrapper index must remain valid")
+					.1
+					.take()
+					.expect("the wrapper must be present before invoking its hook");
+
+				let result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+					invoke(wrapper.as_command_wrapper_mut(), self)
+				}));
+
+				let slot = self
+					.wrappers
+					.get_index_mut(index)
+					.expect("the wrapper key must remain present")
+					.1;
+				debug_assert!(slot.is_none());
+				*slot = Some(wrapper);
+
+				match result {
+					Ok(result) => result,
+					Err(payload) => ::std::panic::resume_unwind(payload),
+				}
+			}
+
 			#[inline]
 			fn spawn_inner(
-				&self,
+				&mut self,
 				command: &mut $command,
-				wrappers: &mut ::indexmap::IndexMap<
-					::std::any::TypeId,
-					Box<dyn ErasedCommandWrapper>,
-				>,
 				spawner: impl FnOnce(&mut $command) -> ::std::io::Result<$child>,
 			) -> ::std::io::Result<Box<dyn $childer>> {
-				for (_id, wrapper) in wrappers.iter_mut() {
+				for index in 0..self.wrappers.len() {
 					#[cfg(feature = "tracing")]
-					::tracing::debug!(id = ?_id, "pre_spawn");
-					wrapper
-						.as_command_wrapper_mut()
-						.pre_spawn(command, self)?;
+					{
+						let id = self.wrappers.get_index(index).unwrap().0;
+						::tracing::debug!(?id, "pre_spawn");
+					}
+					self.with_wrapper_at(index, |wrapper, core| {
+						wrapper.pre_spawn(command, core)
+					})?;
 				}
 
 				let mut child = spawner(command)?;
-				for (_id, wrapper) in wrappers.iter_mut() {
+				for index in 0..self.wrappers.len() {
 					#[cfg(feature = "tracing")]
-					::tracing::debug!(id = ?_id, "post_spawn");
-					wrapper
-						.as_command_wrapper_mut()
-						.post_spawn(command, &mut child, self)?;
+					{
+						let id = self.wrappers.get_index(index).unwrap().0;
+						::tracing::debug!(?id, "post_spawn");
+					}
+					self.with_wrapper_at(index, |wrapper, core| {
+						wrapper.post_spawn(command, &mut child, core)
+					})?;
 				}
 
 				let mut child = Box::new(
@@ -126,12 +164,15 @@ macro_rules! Wrap {
 					$first_child_wrapper(child),
 				) as Box<dyn $childer>;
 
-				for (_id, wrapper) in wrappers.iter_mut() {
+				for index in 0..self.wrappers.len() {
 					#[cfg(feature = "tracing")]
-					::tracing::debug!(id = ?_id, "wrap_child");
-					child = wrapper
-						.as_command_wrapper_mut()
-						.wrap_child(child, self)?;
+					{
+						let id = self.wrappers.get_index(index).unwrap().0;
+						::tracing::debug!(?id, "wrap_child");
+					}
+					child = self.with_wrapper_at(index, |wrapper, core| {
+						wrapper.wrap_child(child, core)
+					})?;
 				}
 
 				Ok(child)
@@ -160,14 +201,16 @@ macro_rules! Wrap {
 				spawner: impl FnOnce(&mut $command) -> ::std::io::Result<$child>,
 			) -> ::std::io::Result<Box<dyn $childer>> {
 				let mut command = ::std::mem::replace(&mut self.command, <$command>::new(""));
-				let mut wrappers = ::std::mem::take(&mut self.wrappers);
-
-				let res = self.spawn_inner(&mut command, &mut wrappers, spawner);
+				let result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+					self.spawn_inner(&mut command, spawner)
+				}));
 
 				self.command = command;
-				self.wrappers = wrappers;
 
-				res
+				match result {
+					Ok(result) => result,
+					Err(payload) => ::std::panic::resume_unwind(payload),
+				}
 			}
 
 			/// Check if a wrapper of a given type is present.
@@ -181,16 +224,21 @@ macro_rules! Wrap {
 			/// This is useful for getting access to the state of a wrapper, generally from within
 			/// another wrapper.
 			///
-			/// Returns `None` if the wrapper is not present. To merely check if a wrapper is
-			/// present, use `has_wrap` instead.
+			/// Returns `None` if the wrapper is not present. While a wrapper's lifecycle hook is
+			/// running, that active wrapper remains registered but is temporarily unavailable through
+			/// this method; peer wrappers remain available. To merely check registration, use
+			/// `has_wrap` instead.
 			pub fn get_wrap<W: CommandWrapper + 'static>(&self) -> Option<&W> {
 				let typeid = ::std::any::TypeId::of::<W>();
-				self.wrappers.get(&typeid).map(|wrapper| {
-					wrapper
-						.as_any()
-						.downcast_ref()
-						.expect("the wrapper key and concrete type must match")
-				})
+				self.wrappers
+					.get(&typeid)
+					.and_then(Option::as_deref)
+					.map(|wrapper| {
+						wrapper
+							.as_any()
+							.downcast_ref()
+							.expect("the wrapper key and concrete type must match")
+					})
 			}
 		}
 

--- a/src/generic_wrap.rs
+++ b/src/generic_wrap.rs
@@ -92,7 +92,7 @@ macro_rules! Wrap {
 				if let Some(wrapper) = wrapper {
 					extant
 						.as_mut()
-						.expect("a wrapper cannot be replaced while its hook is active")
+						.expect("wrap() cannot run while the matching wrapper's hook is active")
 						.as_any_mut()
 						.downcast_mut::<W>()
 						.expect("downcasting is guaranteed to succeed due to wrap()'s internals")
@@ -114,10 +114,10 @@ macro_rules! Wrap {
 				let mut wrapper = self
 					.wrappers
 					.get_index_mut(index)
-					.expect("the wrapper index must remain valid")
+					.expect("wrapper indices cannot disappear during ordered hook traversal")
 					.1
 					.take()
-					.expect("the wrapper must be present before invoking its hook");
+					.expect("each wrapper is present when its lifecycle hook begins");
 
 				let result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
 					invoke(wrapper.as_command_wrapper_mut(), self)
@@ -126,7 +126,7 @@ macro_rules! Wrap {
 				let slot = self
 					.wrappers
 					.get_index_mut(index)
-					.expect("the wrapper key must remain present")
+					.expect("wrapper registrations cannot disappear while their hooks run")
 					.1;
 				debug_assert!(slot.is_none());
 				*slot = Some(wrapper);
@@ -146,7 +146,10 @@ macro_rules! Wrap {
 				for index in 0..self.wrappers.len() {
 					#[cfg(feature = "tracing")]
 					{
-						let id = self.wrappers.get_index(index).unwrap().0;
+						let id = self
+								.wrappers
+								.get_index(index)
+								.expect("wrapper indices cannot disappear during ordered hook traversal").0;
 						::tracing::debug!(?id, "pre_spawn");
 					}
 					self.with_wrapper_at(index, |wrapper, core| {
@@ -158,7 +161,10 @@ macro_rules! Wrap {
 				for index in 0..self.wrappers.len() {
 					#[cfg(feature = "tracing")]
 					{
-						let id = self.wrappers.get_index(index).unwrap().0;
+						let id = self
+								.wrappers
+								.get_index(index)
+								.expect("wrapper indices cannot disappear during ordered hook traversal").0;
 						::tracing::debug!(?id, "post_spawn");
 					}
 					self.with_wrapper_at(index, |wrapper, core| {
@@ -174,7 +180,10 @@ macro_rules! Wrap {
 				for index in 0..self.wrappers.len() {
 					#[cfg(feature = "tracing")]
 					{
-						let id = self.wrappers.get_index(index).unwrap().0;
+						let id = self
+								.wrappers
+								.get_index(index)
+								.expect("wrapper indices cannot disappear during ordered hook traversal").0;
 						::tracing::debug!(?id, "wrap_child");
 					}
 					child = self.with_wrapper_at(index, |wrapper, core| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,8 @@
 //!
 //! Internally the `JobObject` wrapper always sets the `CREATE_SUSPENDED` flag, but as it is able to
 //! access the `CreationFlags` value it will either resume the process after setting up, or leave it
-//! suspended if `CREATE_SUSPENDED` was explicitly set.
+//! suspended if `CREATE_SUSPENDED` was explicitly set. `CreationFlags` and `JobObject` may be
+//! registered in either order.
 //!
 //! # Extension
 //!

--- a/src/std/creation_flags.rs
+++ b/src/std/creation_flags.rs
@@ -4,6 +4,11 @@ use windows::Win32::System::Threading::PROCESS_CREATION_FLAGS;
 
 use super::{CommandWrap, CommandWrapper};
 
+#[cfg(feature = "job-object")]
+use super::JobObject;
+#[cfg(feature = "job-object")]
+use crate::windows::job_creation_flags;
+
 /// Shim wrapper which sets Windows process creation flags.
 ///
 /// This wrapper is only available on Windows.
@@ -12,15 +17,26 @@ use super::{CommandWrap, CommandWrapper};
 /// that they're no overwritten by other wrappers. Notably this is the only way to use creation
 /// flags and the `JobObject` wrapper together.
 ///
-/// When both `CreationFlags` and `JobObject` are used together, either:
-/// - `CreationFlags` must come first, or
-/// - `CreationFlags` must include `CREATE_SUSPENDED`
+/// When both `CreationFlags` and `JobObject` are used, process-wrap preserves these flags while
+/// temporarily adding `CREATE_SUSPENDED`; registration order does not matter.
 #[derive(Clone, Copy, Debug)]
 pub struct CreationFlags(pub PROCESS_CREATION_FLAGS);
 
 impl CommandWrapper for CreationFlags {
-	fn pre_spawn(&mut self, command: &mut Command, _core: &CommandWrap) -> Result<()> {
-		command.creation_flags((self.0).0);
+	fn pre_spawn(&mut self, command: &mut Command, core: &CommandWrap) -> Result<()> {
+		#[cfg(feature = "job-object")]
+		let flags = if core.has_wrap::<JobObject>() {
+			job_creation_flags(self.0).flags
+		} else {
+			self.0
+		};
+		#[cfg(not(feature = "job-object"))]
+		let flags = {
+			let _ = core;
+			self.0
+		};
+
+		command.creation_flags(flags.0);
 		Ok(())
 	}
 }

--- a/src/std/job_object.rs
+++ b/src/std/job_object.rs
@@ -9,12 +9,14 @@ use std::{
 use tracing::{debug, instrument};
 use windows::Win32::{
 	Foundation::{CloseHandle, HANDLE},
-	System::Threading::CREATE_SUSPENDED,
+	System::Threading::PROCESS_CREATION_FLAGS,
 };
 
 use crate::{
 	ChildExitStatus,
-	windows::{JobPort, make_job_object, resume_threads, terminate_job, wait_on_job},
+	windows::{
+		JobPort, job_creation_flags, make_job_object, resume_threads, terminate_job, wait_on_job,
+	},
 };
 
 #[cfg(feature = "creation-flags")]
@@ -31,48 +33,68 @@ use super::{ChildWrapper, CommandWrap, CommandWrapper};
 ///
 /// This wrapper provides a child wrapper: [`JobObjectChild`].
 ///
-/// When both [`CreationFlags`] and [`JobObject`] are used together, either:
-/// - `CreationFlags` must come first, or
-/// - `CreationFlags` must include `CREATE_SUSPENDED`
+/// [`CreationFlags`] may be registered before or after `JobObject`; process-wrap preserves its flags
+/// and distinguishes explicit suspension from the temporary suspension needed for assignment.
 #[derive(Clone, Copy, Debug)]
 pub struct JobObject;
+
+fn user_creation_flags(core: &CommandWrap) -> PROCESS_CREATION_FLAGS {
+	#[cfg(feature = "creation-flags")]
+	{
+		core.get_wrap::<CreationFlags>()
+			.map_or(PROCESS_CREATION_FLAGS(0), |flags| flags.0)
+	}
+	#[cfg(not(feature = "creation-flags"))]
+	{
+		let _ = core;
+		PROCESS_CREATION_FLAGS(0)
+	}
+}
+
+fn terminate_child(child: &mut dyn ChildWrapper) {
+	if child.start_kill().is_ok() {
+		let _ = child.wait();
+	}
+}
 
 impl CommandWrapper for JobObject {
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn pre_spawn(&mut self, command: &mut Command, core: &CommandWrap) -> Result<()> {
-		let mut flags = CREATE_SUSPENDED;
-		#[cfg(feature = "creation-flags")]
-		if let Some(CreationFlags(user_flags)) = core.get_wrap::<CreationFlags>() {
-			flags |= *user_flags;
-		}
-
-		command.creation_flags(flags.0);
+		let policy = job_creation_flags(user_creation_flags(core));
+		command.creation_flags(policy.flags.0);
 		Ok(())
 	}
 
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn wrap_child(
 		&mut self,
-		inner: Box<dyn ChildWrapper>,
+		mut inner: Box<dyn ChildWrapper>,
 		core: &CommandWrap,
 	) -> Result<Box<dyn ChildWrapper>> {
-		#[cfg(feature = "creation-flags")]
-		let create_suspended = core
-			.get_wrap::<CreationFlags>()
-			.map_or(false, |flags| flags.0.contains(CREATE_SUSPENDED));
-		#[cfg(not(feature = "creation-flags"))]
-		let create_suspended = false;
+		let policy = job_creation_flags(user_creation_flags(core));
 
 		#[cfg(feature = "tracing")]
-		debug!(?create_suspended, "options from other wrappers");
+		debug!(
+			resume_after_assignment = policy.resume_after_assignment,
+			"options from other wrappers"
+		);
 
 		let handle = HANDLE(inner.inner_child().as_raw_handle() as _);
 
-		let job_port = make_job_object(handle, false)?;
+		let job_port = match make_job_object(handle, false) {
+			Ok(job_port) => job_port,
+			Err(error) => {
+				terminate_child(&mut *inner);
+				return Err(error);
+			}
+		};
 
-		// only resume if the user didn't specify CREATE_SUSPENDED
-		if !create_suspended {
-			resume_threads(handle)?;
+		if policy.resume_after_assignment {
+			if let Err(error) = resume_threads(handle) {
+				let _ = terminate_job(job_port.job, 1);
+				terminate_child(&mut *inner);
+				return Err(error);
+			}
 		}
 
 		Ok(Box::new(JobObjectChild::new(inner, job_port)))

--- a/src/tokio/creation_flags.rs
+++ b/src/tokio/creation_flags.rs
@@ -5,6 +5,11 @@ use windows::Win32::System::Threading::PROCESS_CREATION_FLAGS;
 
 use super::{CommandWrap, CommandWrapper};
 
+#[cfg(feature = "job-object")]
+use super::JobObject;
+#[cfg(feature = "job-object")]
+use crate::windows::job_creation_flags;
+
 /// Shim wrapper which sets Windows process creation flags.
 ///
 /// This wrapper is only available on Windows.
@@ -13,15 +18,26 @@ use super::{CommandWrap, CommandWrapper};
 /// that they're no overwritten by other wrappers. Notably this is the only way to use creation
 /// flags and the `JobObject` wrapper together.
 ///
-/// When both `CreationFlags` and `JobObject` are used together, either:
-/// - `CreationFlags` must come first, or
-/// - `CreationFlags` must include `CREATE_SUSPENDED`
+/// When both `CreationFlags` and `JobObject` are used, process-wrap preserves these flags while
+/// temporarily adding `CREATE_SUSPENDED`; registration order does not matter.
 #[derive(Clone, Copy, Debug)]
 pub struct CreationFlags(pub PROCESS_CREATION_FLAGS);
 
 impl CommandWrapper for CreationFlags {
-	fn pre_spawn(&mut self, command: &mut Command, _core: &CommandWrap) -> Result<()> {
-		command.creation_flags((self.0).0);
+	fn pre_spawn(&mut self, command: &mut Command, core: &CommandWrap) -> Result<()> {
+		#[cfg(feature = "job-object")]
+		let flags = if core.has_wrap::<JobObject>() {
+			job_creation_flags(self.0).flags
+		} else {
+			self.0
+		};
+		#[cfg(not(feature = "job-object"))]
+		let flags = {
+			let _ = core;
+			self.0
+		};
+
+		command.creation_flags(flags.0);
 		Ok(())
 	}
 }

--- a/src/tokio/job_object.rs
+++ b/src/tokio/job_object.rs
@@ -5,12 +5,14 @@ use tokio::{process::Command, task::spawn_blocking};
 use tracing::{debug, instrument};
 use windows::Win32::{
 	Foundation::{CloseHandle, HANDLE},
-	System::Threading::CREATE_SUSPENDED,
+	System::Threading::PROCESS_CREATION_FLAGS,
 };
 
 use crate::{
 	ChildExitStatus,
-	windows::{JobPort, make_job_object, resume_threads, terminate_job, wait_on_job},
+	windows::{
+		JobPort, job_creation_flags, make_job_object, resume_threads, terminate_job, wait_on_job,
+	},
 };
 
 #[cfg(feature = "creation-flags")]
@@ -29,29 +31,40 @@ use super::{ChildWrapper, CommandWrap, CommandWrapper};
 ///
 /// This wrapper provides a child wrapper: [`JobObjectChild`].
 ///
-/// When both [`CreationFlags`] and [`JobObject`] are used together, either:
-/// - `CreationFlags` must come first, or
-/// - `CreationFlags` must include `CREATE_SUSPENDED`
+/// [`CreationFlags`] may be registered before or after `JobObject`; process-wrap preserves its flags
+/// and distinguishes explicit suspension from the temporary suspension needed for assignment.
 #[derive(Clone, Copy, Debug)]
 pub struct JobObject;
+
+fn user_creation_flags(core: &CommandWrap) -> PROCESS_CREATION_FLAGS {
+	#[cfg(feature = "creation-flags")]
+	{
+		core.get_wrap::<CreationFlags>()
+			.map_or(PROCESS_CREATION_FLAGS(0), |flags| flags.0)
+	}
+	#[cfg(not(feature = "creation-flags"))]
+	{
+		let _ = core;
+		PROCESS_CREATION_FLAGS(0)
+	}
+}
+
+fn terminate_child(child: &mut dyn ChildWrapper) {
+	let _ = child.start_kill();
+}
 
 impl CommandWrapper for JobObject {
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn pre_spawn(&mut self, command: &mut Command, core: &CommandWrap) -> Result<()> {
-		let mut flags = CREATE_SUSPENDED;
-		#[cfg(feature = "creation-flags")]
-		if let Some(CreationFlags(user_flags)) = core.get_wrap::<CreationFlags>() {
-			flags |= *user_flags;
-		}
-
-		command.creation_flags(flags.0);
+		let policy = job_creation_flags(user_creation_flags(core));
+		command.creation_flags(policy.flags.0);
 		Ok(())
 	}
 
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn wrap_child(
 		&mut self,
-		inner: Box<dyn ChildWrapper>,
+		mut inner: Box<dyn ChildWrapper>,
 		core: &CommandWrap,
 	) -> Result<Box<dyn ChildWrapper>> {
 		#[cfg(feature = "kill-on-drop")]
@@ -59,17 +72,12 @@ impl CommandWrapper for JobObject {
 		#[cfg(not(feature = "kill-on-drop"))]
 		let kill_on_drop = false;
 
-		#[cfg(feature = "creation-flags")]
-		let create_suspended = core
-			.get_wrap::<CreationFlags>()
-			.map_or(false, |flags| flags.0.contains(CREATE_SUSPENDED));
-		#[cfg(not(feature = "creation-flags"))]
-		let create_suspended = false;
+		let policy = job_creation_flags(user_creation_flags(core));
 
 		#[cfg(feature = "tracing")]
 		debug!(
 			?kill_on_drop,
-			?create_suspended,
+			resume_after_assignment = policy.resume_after_assignment,
 			"options from other wrappers"
 		);
 
@@ -80,11 +88,20 @@ impl CommandWrapper for JobObject {
 				.expect("child has exited but it has not even started") as _,
 		);
 
-		let job_port = make_job_object(handle, kill_on_drop)?;
+		let job_port = match make_job_object(handle, kill_on_drop) {
+			Ok(job_port) => job_port,
+			Err(error) => {
+				terminate_child(&mut *inner);
+				return Err(error);
+			}
+		};
 
-		// only resume if the user didn't specify CREATE_SUSPENDED
-		if !create_suspended {
-			resume_threads(handle)?;
+		if policy.resume_after_assignment {
+			if let Err(error) = resume_threads(handle) {
+				let _ = terminate_job(job_port.job, 1);
+				terminate_child(&mut *inner);
+				return Err(error);
+			}
 		}
 
 		Ok(Box::new(JobObjectChild::new(inner, job_port)))

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -189,7 +189,7 @@ pub(crate) fn resume_threads(child_process: HANDLE) -> Result<()> {
 		let mut entry = THREADENTRY32 {
 			dwSize: std::mem::size_of::<THREADENTRY32>()
 				.try_into()
-				.expect("THREADENTRY32 size must fit in a DWORD"),
+				.expect("THREADENTRY32 is guaranteed to fit in a DWORD"),
 			..Default::default()
 		};
 		unsafe { Thread32First(tool_handle, &mut entry) }.map_err(Error::other)?;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -8,22 +8,82 @@ use std::{
 
 #[cfg(feature = "tracing")]
 use tracing::{debug, instrument};
-use windows::Win32::{
-	Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
-	System::{
-		Diagnostics::ToolHelp::{
-			CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
+use windows::{
+	Win32::{
+		Foundation::{CloseHandle, ERROR_NO_MORE_FILES, HANDLE, INVALID_HANDLE_VALUE},
+		System::{
+			Diagnostics::ToolHelp::{
+				CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First,
+				Thread32Next,
+			},
+			IO::{CreateIoCompletionPort, GetQueuedCompletionStatus, OVERLAPPED},
+			JobObjects::{
+				AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+				JOBOBJECT_ASSOCIATE_COMPLETION_PORT, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+				JobObjectAssociateCompletionPortInformation, JobObjectExtendedLimitInformation,
+				SetInformationJobObject, TerminateJobObject,
+			},
+			Threading::{
+				CREATE_SUSPENDED, GetProcessId, INFINITE, OpenThread, PROCESS_CREATION_FLAGS,
+				ResumeThread, THREAD_SUSPEND_RESUME,
+			},
 		},
-		IO::{CreateIoCompletionPort, GetQueuedCompletionStatus, OVERLAPPED},
-		JobObjects::{
-			AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-			JOBOBJECT_ASSOCIATE_COMPLETION_PORT, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
-			JobObjectAssociateCompletionPortInformation, JobObjectExtendedLimitInformation,
-			SetInformationJobObject, TerminateJobObject,
-		},
-		Threading::{GetProcessId, INFINITE, OpenThread, ResumeThread, THREAD_SUSPEND_RESUME},
 	},
+	core::HRESULT,
 };
+
+#[derive(Debug)]
+struct OwnedHandle(HANDLE);
+
+impl OwnedHandle {
+	fn into_raw(self) -> HANDLE {
+		let handle = self.0;
+		std::mem::forget(self);
+		handle
+	}
+}
+
+impl Drop for OwnedHandle {
+	fn drop(&mut self) {
+		unsafe { CloseHandle(self.0) }.ok();
+	}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct JobCreationFlags {
+	pub flags: PROCESS_CREATION_FLAGS,
+	pub resume_after_assignment: bool,
+}
+
+pub(crate) fn job_creation_flags(user_flags: PROCESS_CREATION_FLAGS) -> JobCreationFlags {
+	JobCreationFlags {
+		flags: user_flags | CREATE_SUSPENDED,
+		resume_after_assignment: !user_flags.contains(CREATE_SUSPENDED),
+	}
+}
+
+#[cfg(test)]
+mod creation_flag_tests {
+	use windows::Win32::System::Threading::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
+
+	use super::*;
+
+	#[test]
+	fn adds_suspension_without_losing_user_flags() {
+		let user_flags = CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW;
+		let policy = job_creation_flags(user_flags);
+		assert_eq!(policy.flags, user_flags | CREATE_SUSPENDED);
+		assert!(policy.resume_after_assignment);
+	}
+
+	#[test]
+	fn preserves_explicit_suspension() {
+		let user_flags = CREATE_NO_WINDOW | CREATE_SUSPENDED;
+		let policy = job_creation_flags(user_flags);
+		assert_eq!(policy.flags, user_flags);
+		assert!(!policy.resume_after_assignment);
+	}
+}
 
 #[derive(Clone, Copy, Debug)]
 pub struct JobHandle(pub HANDLE);
@@ -59,12 +119,12 @@ impl Drop for JobPort {
 /// essentially implements the "reap children" feature of Unix systems directly in Win32.
 #[cfg_attr(feature = "tracing", instrument(level = "debug"))]
 pub(crate) fn make_job_object(process_handle: HANDLE, kill_on_drop: bool) -> Result<JobPort> {
-	let job = JobHandle(unsafe { CreateJobObjectW(None, None) }.map_err(Error::other)?);
+	let job = OwnedHandle(unsafe { CreateJobObjectW(None, None) }.map_err(Error::other)?);
 	#[cfg(feature = "tracing")]
 	debug!(?job, "done CreateJobObjectW");
 
 	let completion_port =
-		PortHandle(unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, None, 0, 1) }?);
+		OwnedHandle(unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, None, 0, 1) }?);
 	#[cfg(feature = "tracing")]
 	debug!(?completion_port, "done CreateIoCompletionPort");
 
@@ -113,8 +173,8 @@ pub(crate) fn make_job_object(process_handle: HANDLE, kill_on_drop: bool) -> Res
 	debug!(?job, ?process_handle, "done AssignProcessToJobObject");
 
 	Ok(JobPort {
-		job,
-		completion_port,
+		job: JobHandle(job.into_raw()),
+		completion_port: PortHandle(completion_port.into_raw()),
 	})
 }
 
@@ -127,38 +187,51 @@ pub(crate) fn resume_threads(child_process: HANDLE) -> Result<()> {
 	#[inline]
 	unsafe fn inner(pid: u32, tool_handle: HANDLE) -> Result<()> {
 		let mut entry = THREADENTRY32 {
-			dwSize: 28,
-			cntUsage: 0,
-			th32ThreadID: 0,
-			th32OwnerProcessID: 0,
-			tpBasePri: 0,
-			tpDeltaPri: 0,
-			dwFlags: 0,
+			dwSize: std::mem::size_of::<THREADENTRY32>()
+				.try_into()
+				.expect("THREADENTRY32 size must fit in a DWORD"),
+			..Default::default()
 		};
+		unsafe { Thread32First(tool_handle, &mut entry) }.map_err(Error::other)?;
 
-		let mut res = unsafe { Thread32First(tool_handle, &mut entry) };
-		while res.is_ok() {
+		let mut resumed = false;
+		loop {
 			if entry.th32OwnerProcessID == pid {
-				let thread_handle =
-					unsafe { OpenThread(THREAD_SUSPEND_RESUME, false, entry.th32ThreadID) }?;
-				if unsafe { ResumeThread(thread_handle) } == u32::MAX {
-					unsafe { CloseHandle(thread_handle) }?;
+				let thread_handle = OwnedHandle(unsafe {
+					OpenThread(THREAD_SUSPEND_RESUME, false, entry.th32ThreadID)
+				}?);
+				let previous_count = unsafe { ResumeThread(thread_handle.0) };
+				if previous_count == u32::MAX {
 					return Err(Error::last_os_error());
 				}
-				unsafe { CloseHandle(thread_handle) }?;
+				if previous_count > 0 {
+					resumed = true;
+				}
 			}
 
-			res = unsafe { Thread32Next(tool_handle, &mut entry) };
+			match unsafe { Thread32Next(tool_handle, &mut entry) } {
+				Ok(()) => {}
+				Err(error) if error.code() == HRESULT::from_win32(ERROR_NO_MORE_FILES.0) => {
+					break;
+				}
+				Err(error) => return Err(Error::other(error)),
+			}
 		}
 
-		Ok(())
+		if resumed {
+			Ok(())
+		} else {
+			Err(Error::other("no thread belonging to the child was found"))
+		}
 	}
 
 	let child_id = unsafe { GetProcessId(child_process) };
-	let tool_handle = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) }?;
-	let ret = unsafe { inner(child_id, tool_handle) };
-	unsafe { CloseHandle(tool_handle) }.map_err(Error::other)?;
-	ret
+	if child_id == 0 {
+		return Err(Error::last_os_error());
+	}
+
+	let tool_handle = OwnedHandle(unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) }?);
+	unsafe { inner(child_id, tool_handle.0) }
 }
 
 /// Terminate a job object without waiting for the processes to exit.

--- a/tests/std_windows/creation_flags_job_object.rs
+++ b/tests/std_windows/creation_flags_job_object.rs
@@ -1,0 +1,97 @@
+use std::{
+	io::{Error, ErrorKind},
+	process::ExitStatus,
+	time::Instant,
+};
+
+use windows::Win32::System::Threading::{
+	CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_SUSPENDED, PROCESS_CREATION_FLAGS,
+};
+
+use super::{prelude::*, windows_thread::process_has_suspended_thread};
+
+const EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy)]
+enum Order {
+	CreationFlagsFirst,
+	JobObjectFirst,
+}
+
+fn command(flags: PROCESS_CREATION_FLAGS, order: Order) -> CommandWrap {
+	let mut command = CommandWrap::with_new("cmd.exe", |command| {
+		command.args(["/D", "/S", "/C", "exit /b 0"]);
+	});
+	match order {
+		Order::CreationFlagsFirst => {
+			command.wrap(CreationFlags(flags)).wrap(JobObject);
+		}
+		Order::JobObjectFirst => {
+			command.wrap(JobObject).wrap(CreationFlags(flags));
+		}
+	}
+	command
+}
+
+fn wait_for_exit(child: &mut dyn ChildWrapper) -> Result<ExitStatus> {
+	let deadline = Instant::now() + EXIT_TIMEOUT;
+	loop {
+		if let Some(status) = child.try_wait()? {
+			return Ok(status);
+		}
+		if Instant::now() >= deadline {
+			let _ = child.start_kill();
+			return Err(Error::new(ErrorKind::TimedOut, "child did not exit"));
+		}
+		sleep(Duration::from_millis(10));
+	}
+}
+
+#[test]
+fn preserves_flags_and_resumes_in_both_orders() -> Result<()> {
+	let flags = CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW;
+	for order in [Order::CreationFlagsFirst, Order::JobObjectFirst] {
+		let mut command = command(flags, order);
+		assert_eq!(command.get_wrap::<CreationFlags>().unwrap().0, flags);
+		let mut child = command.spawn_with(|command| {
+			let mut child = command.spawn()?;
+			let suspended = match process_has_suspended_thread(child.id()) {
+				Ok(suspended) => suspended,
+				Err(error) => {
+					let _ = child.kill();
+					return Err(error);
+				}
+			};
+			if suspended {
+				Ok(child)
+			} else {
+				let _ = child.kill();
+				Err(Error::other("child was not created suspended"))
+			}
+		})?;
+		assert_eq!(command.get_wrap::<CreationFlags>().unwrap().0, flags);
+		assert!(wait_for_exit(&mut *child)?.success());
+	}
+	Ok(())
+}
+
+#[test]
+fn leaves_explicit_suspension_in_both_orders() -> Result<()> {
+	let flags = CREATE_NO_WINDOW | CREATE_SUSPENDED;
+	for order in [Order::CreationFlagsFirst, Order::JobObjectFirst] {
+		let mut command = command(flags, order);
+		let mut child = command.spawn()?;
+		let remained_suspended = match process_has_suspended_thread(child.id()) {
+			Ok(suspended) => suspended,
+			Err(error) => {
+				let _ = child.start_kill();
+				return Err(error);
+			}
+		};
+		child.start_kill()?;
+		let _ = wait_for_exit(&mut *child)?;
+		assert!(remained_suspended);
+		assert_eq!(command.get_wrap::<CreationFlags>().unwrap().0, flags);
+	}
+	Ok(())
+}

--- a/tests/std_windows/mod.rs
+++ b/tests/std_windows/mod.rs
@@ -11,6 +11,8 @@ mod prelude {
 	pub const DIE_TIME: Duration = Duration::from_millis(1000);
 }
 
+#[cfg(all(feature = "creation-flags", feature = "job-object"))]
+mod creation_flags_job_object;
 mod id_same_as_inner;
 mod inner_read_stdout;
 mod into_inner_write_stdin;
@@ -19,3 +21,6 @@ mod try_wait_after_die;
 mod wait_after_die;
 mod wait_twice;
 mod wait_with_output;
+#[cfg(all(feature = "creation-flags", feature = "job-object"))]
+#[path = "../support/windows_thread.rs"]
+mod windows_thread;

--- a/tests/support/windows_thread.rs
+++ b/tests/support/windows_thread.rs
@@ -27,7 +27,7 @@ pub fn process_has_suspended_thread(pid: u32) -> Result<bool> {
 	let mut entry = THREADENTRY32 {
 		dwSize: std::mem::size_of::<THREADENTRY32>()
 			.try_into()
-			.expect("THREADENTRY32 size must fit in a DWORD"),
+			.expect("THREADENTRY32 is guaranteed to fit in a DWORD"),
 		..Default::default()
 	};
 	unsafe { Thread32First(snapshot.0, &mut entry) }.map_err(Error::other)?;

--- a/tests/support/windows_thread.rs
+++ b/tests/support/windows_thread.rs
@@ -1,0 +1,69 @@
+use std::io::{Error, Result};
+
+use windows::{
+	Win32::{
+		Foundation::{CloseHandle, ERROR_NO_MORE_FILES, HANDLE},
+		System::{
+			Diagnostics::ToolHelp::{
+				CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First,
+				Thread32Next,
+			},
+			Threading::{OpenThread, ResumeThread, SuspendThread, THREAD_SUSPEND_RESUME},
+		},
+	},
+	core::HRESULT,
+};
+
+struct OwnedHandle(HANDLE);
+
+impl Drop for OwnedHandle {
+	fn drop(&mut self) {
+		unsafe { CloseHandle(self.0) }.ok();
+	}
+}
+
+pub fn process_has_suspended_thread(pid: u32) -> Result<bool> {
+	let snapshot = OwnedHandle(unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) }?);
+	let mut entry = THREADENTRY32 {
+		dwSize: std::mem::size_of::<THREADENTRY32>()
+			.try_into()
+			.expect("THREADENTRY32 size must fit in a DWORD"),
+		..Default::default()
+	};
+	unsafe { Thread32First(snapshot.0, &mut entry) }.map_err(Error::other)?;
+
+	let mut found = false;
+	let mut suspended = false;
+	loop {
+		if entry.th32OwnerProcessID == pid {
+			found = true;
+			let thread = OwnedHandle(unsafe {
+				OpenThread(THREAD_SUSPEND_RESUME, false, entry.th32ThreadID)
+			}?);
+			let previous_count = unsafe { SuspendThread(thread.0) };
+			if previous_count == u32::MAX {
+				return Err(Error::last_os_error());
+			}
+			let balanced_count = unsafe { ResumeThread(thread.0) };
+			if balanced_count == u32::MAX {
+				return Err(Error::last_os_error());
+			}
+			if balanced_count != previous_count + 1 {
+				return Err(Error::other("thread suspension probe was not balanced"));
+			}
+			suspended |= previous_count > 0;
+		}
+
+		match unsafe { Thread32Next(snapshot.0, &mut entry) } {
+			Ok(()) => {}
+			Err(error) if error.code() == HRESULT::from_win32(ERROR_NO_MORE_FILES.0) => break,
+			Err(error) => return Err(Error::other(error)),
+		}
+	}
+
+	if found {
+		Ok(suspended)
+	} else {
+		Err(Error::other("no thread belonging to the child was found"))
+	}
+}

--- a/tests/tokio_windows/creation_flags_job_object.rs
+++ b/tests/tokio_windows/creation_flags_job_object.rs
@@ -1,0 +1,99 @@
+use std::{
+	io::{Error, ErrorKind},
+	process::ExitStatus,
+	time::Instant,
+};
+
+use windows::Win32::System::Threading::{
+	CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_SUSPENDED, PROCESS_CREATION_FLAGS,
+};
+
+use super::{prelude::*, windows_thread::process_has_suspended_thread};
+
+const EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy)]
+enum Order {
+	CreationFlagsFirst,
+	JobObjectFirst,
+}
+
+fn command(flags: PROCESS_CREATION_FLAGS, order: Order) -> CommandWrap {
+	let mut command = CommandWrap::with_new("cmd.exe", |command| {
+		command.args(["/D", "/S", "/C", "exit /b 0"]);
+	});
+	match order {
+		Order::CreationFlagsFirst => {
+			command.wrap(CreationFlags(flags)).wrap(JobObject);
+		}
+		Order::JobObjectFirst => {
+			command.wrap(JobObject).wrap(CreationFlags(flags));
+		}
+	}
+	command
+}
+
+async fn wait_for_exit(child: &mut dyn ChildWrapper) -> Result<ExitStatus> {
+	let deadline = Instant::now() + EXIT_TIMEOUT;
+	loop {
+		if let Some(status) = child.try_wait()? {
+			return Ok(status);
+		}
+		if Instant::now() >= deadline {
+			let _ = child.start_kill();
+			return Err(Error::new(ErrorKind::TimedOut, "child did not exit"));
+		}
+		sleep(Duration::from_millis(10)).await;
+	}
+}
+
+#[tokio::test]
+async fn preserves_flags_and_resumes_in_both_orders() -> Result<()> {
+	let flags = CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW;
+	for order in [Order::CreationFlagsFirst, Order::JobObjectFirst] {
+		let mut command = command(flags, order);
+		assert_eq!(command.get_wrap::<CreationFlags>().unwrap().0, flags);
+		let mut child = command.spawn_with(|command| {
+			let mut child = command.spawn()?;
+			let suspended =
+				match process_has_suspended_thread(child.id().expect("child must have an id")) {
+					Ok(suspended) => suspended,
+					Err(error) => {
+						let _ = child.start_kill();
+						return Err(error);
+					}
+				};
+			if suspended {
+				Ok(child)
+			} else {
+				let _ = child.start_kill();
+				Err(Error::other("child was not created suspended"))
+			}
+		})?;
+		assert_eq!(command.get_wrap::<CreationFlags>().unwrap().0, flags);
+		assert!(wait_for_exit(&mut *child).await?.success());
+	}
+	Ok(())
+}
+
+#[tokio::test]
+async fn leaves_explicit_suspension_in_both_orders() -> Result<()> {
+	let flags = CREATE_NO_WINDOW | CREATE_SUSPENDED;
+	for order in [Order::CreationFlagsFirst, Order::JobObjectFirst] {
+		let mut command = command(flags, order);
+		let mut child = command.spawn()?;
+		let remained_suspended =
+			match process_has_suspended_thread(child.id().expect("child must have an id")) {
+				Ok(suspended) => suspended,
+				Err(error) => {
+					let _ = child.start_kill();
+					return Err(error);
+				}
+			};
+		child.start_kill()?;
+		let _ = wait_for_exit(&mut *child).await?;
+		assert!(remained_suspended);
+		assert_eq!(command.get_wrap::<CreationFlags>().unwrap().0, flags);
+	}
+	Ok(())
+}

--- a/tests/tokio_windows/creation_flags_job_object.rs
+++ b/tests/tokio_windows/creation_flags_job_object.rs
@@ -55,14 +55,17 @@ async fn preserves_flags_and_resumes_in_both_orders() -> Result<()> {
 		assert_eq!(command.get_wrap::<CreationFlags>().unwrap().0, flags);
 		let mut child = command.spawn_with(|command| {
 			let mut child = command.spawn()?;
-			let suspended =
-				match process_has_suspended_thread(child.id().expect("child must have an id")) {
-					Ok(suspended) => suspended,
-					Err(error) => {
-						let _ = child.start_kill();
-						return Err(error);
-					}
-				};
+			let suspended = match process_has_suspended_thread(
+				child
+					.id()
+					.expect("a newly spawned child exposes its process ID before it is reaped"),
+			) {
+				Ok(suspended) => suspended,
+				Err(error) => {
+					let _ = child.start_kill();
+					return Err(error);
+				}
+			};
 			if suspended {
 				Ok(child)
 			} else {
@@ -82,14 +85,17 @@ async fn leaves_explicit_suspension_in_both_orders() -> Result<()> {
 	for order in [Order::CreationFlagsFirst, Order::JobObjectFirst] {
 		let mut command = command(flags, order);
 		let mut child = command.spawn()?;
-		let remained_suspended =
-			match process_has_suspended_thread(child.id().expect("child must have an id")) {
-				Ok(suspended) => suspended,
-				Err(error) => {
-					let _ = child.start_kill();
-					return Err(error);
-				}
-			};
+		let remained_suspended = match process_has_suspended_thread(
+			child
+				.id()
+				.expect("a newly spawned child exposes its process ID before it is reaped"),
+		) {
+			Ok(suspended) => suspended,
+			Err(error) => {
+				let _ = child.start_kill();
+				return Err(error);
+			}
+		};
 		child.start_kill()?;
 		let _ = wait_for_exit(&mut *child).await?;
 		assert!(remained_suspended);

--- a/tests/tokio_windows/job_object_kill_on_drop.rs
+++ b/tests/tokio_windows/job_object_kill_on_drop.rs
@@ -63,10 +63,13 @@ async fn descendant_pid(child: &mut dyn ChildWrapper) -> Result<u32> {
 	})?;
 	let mut lines = BufReader::new(stdout).lines();
 	let result = tokio::time::timeout(STARTUP_TIMEOUT, async {
+		let mut transcript = String::new();
 		while let Some(line) = lines.next_line().await? {
 			if let Some(pid) = line.strip_prefix(DESCENDANT_MARKER) {
 				return pid.trim().parse().map_err(std::io::Error::other);
 			}
+			transcript.push_str(&line);
+			transcript.push('\n');
 		}
 
 		let status = child.wait().await?;
@@ -75,7 +78,7 @@ async fn descendant_pid(child: &mut dyn ChildWrapper) -> Result<u32> {
 			pipe.read_to_string(&mut stderr).await?;
 		}
 		Err(std::io::Error::other(format!(
-			"descendant helper exited with {status} before reporting its pid: {stderr}"
+			"descendant helper exited with {status} before reporting its pid; stdout: {transcript}; stderr: {stderr}"
 		)))
 	})
 	.await;
@@ -122,12 +125,7 @@ fn descendant_leaf() {
 #[ignore = "subprocess helper"]
 fn descendant_parent() {
 	let mut descendant = StdCommand::new(std::env::current_exe().unwrap())
-		.args([
-			"--ignored",
-			"--exact",
-			concat!(module_path!(), "::descendant_leaf"),
-			"--nocapture",
-		])
+		.args(["descendant_leaf", "--ignored", "--nocapture"])
 		.spawn()
 		.unwrap();
 	println!("{DESCENDANT_MARKER}{}", descendant.id());
@@ -140,12 +138,7 @@ async fn job_detects_kill_on_drop_in_both_orders() -> Result<()> {
 	for order in [Order::KillOnDropFirst, Order::JobObjectFirst] {
 		let mut command = CommandWrap::with_new(std::env::current_exe()?, |command| {
 			command
-				.args([
-					"--ignored",
-					"--exact",
-					concat!(module_path!(), "::descendant_parent"),
-					"--nocapture",
-				])
+				.args(["descendant_parent", "--ignored", "--nocapture"])
 				.stdout(Stdio::piped())
 				.stderr(Stdio::piped());
 		});

--- a/tests/tokio_windows/job_object_kill_on_drop.rs
+++ b/tests/tokio_windows/job_object_kill_on_drop.rs
@@ -34,7 +34,8 @@ impl ProcessGuard {
 	}
 
 	fn handle(&self) -> HANDLE {
-		self.0.expect("the process guard must still be armed")
+		self.0
+			.expect("only ProcessGuard::disarm clears the handle, and it consumes the guard")
 	}
 
 	fn disarm(mut self) -> Result<()> {

--- a/tests/tokio_windows/job_object_kill_on_drop.rs
+++ b/tests/tokio_windows/job_object_kill_on_drop.rs
@@ -1,6 +1,10 @@
-use std::{fs::read_to_string, io::ErrorKind, time::Instant};
+use std::{
+	io::{ErrorKind, Write},
+	process::Command as StdCommand,
+	time::Instant,
+};
 
-use tempfile::NamedTempFile;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use windows::Win32::{
 	Foundation::{CloseHandle, HANDLE, WAIT_FAILED, WAIT_OBJECT_0},
 	System::Threading::{
@@ -12,6 +16,7 @@ use super::prelude::*;
 
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
 const EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+const DESCENDANT_MARKER: &str = "PW-DESCENDANT:";
 
 #[derive(Clone, Copy)]
 enum Order {
@@ -49,24 +54,41 @@ impl Drop for ProcessGuard {
 	}
 }
 
-async fn descendant_pid(file: &NamedTempFile) -> Result<u32> {
-	let deadline = Instant::now() + STARTUP_TIMEOUT;
-	loop {
-		match read_to_string(file.path()) {
-			Ok(contents) if !contents.trim().is_empty() => {
-				return contents.trim().parse().map_err(std::io::Error::other);
+async fn descendant_pid(child: &mut dyn ChildWrapper) -> Result<u32> {
+	let stdout = child.stdout().take().ok_or_else(|| {
+		std::io::Error::new(
+			ErrorKind::BrokenPipe,
+			"descendant helper stdout was not piped",
+		)
+	})?;
+	let mut lines = BufReader::new(stdout).lines();
+	let result = tokio::time::timeout(STARTUP_TIMEOUT, async {
+		while let Some(line) = lines.next_line().await? {
+			if let Some(pid) = line.strip_prefix(DESCENDANT_MARKER) {
+				return pid.trim().parse().map_err(std::io::Error::other);
 			}
-			Ok(_) => {}
-			Err(error) if error.kind() == ErrorKind::NotFound => {}
-			Err(error) => return Err(error),
 		}
-		if Instant::now() >= deadline {
-			return Err(std::io::Error::new(
-				ErrorKind::TimedOut,
-				"descendant pid was not written",
-			));
+
+		let status = child.wait().await?;
+		let mut stderr = String::new();
+		if let Some(mut pipe) = child.stderr().take() {
+			pipe.read_to_string(&mut stderr).await?;
 		}
-		sleep(Duration::from_millis(10)).await;
+		Err(std::io::Error::other(format!(
+			"descendant helper exited with {status} before reporting its pid: {stderr}"
+		)))
+	})
+	.await;
+
+	match result {
+		Ok(result) => result,
+		Err(_) => Err(std::io::Error::new(
+			ErrorKind::TimedOut,
+			format!(
+				"descendant helper did not report its pid; process status: {:?}",
+				child.try_wait()?
+			),
+		)),
 	}
 }
 
@@ -90,16 +112,42 @@ async fn wait_for_process_exit(handle: HANDLE) -> Result<()> {
 	}
 }
 
+#[test]
+#[ignore = "subprocess helper"]
+fn descendant_leaf() {
+	std::thread::sleep(Duration::from_secs(300));
+}
+
+#[test]
+#[ignore = "subprocess helper"]
+fn descendant_parent() {
+	let mut descendant = StdCommand::new(std::env::current_exe().unwrap())
+		.args([
+			"--ignored",
+			"--exact",
+			concat!(module_path!(), "::descendant_leaf"),
+			"--nocapture",
+		])
+		.spawn()
+		.unwrap();
+	println!("{DESCENDANT_MARKER}{}", descendant.id());
+	std::io::stdout().flush().unwrap();
+	descendant.wait().unwrap();
+}
+
 #[tokio::test]
 async fn job_detects_kill_on_drop_in_both_orders() -> Result<()> {
 	for order in [Order::KillOnDropFirst, Order::JobObjectFirst] {
-		let pid_file = NamedTempFile::new()?;
-		let path = pid_file.path().display().to_string().replace('\'', "''");
-		let script = format!(
-			"$child = Start-Process powershell.exe -ArgumentList @('-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 300') -PassThru; Set-Content -LiteralPath '{path}' -Value $child.Id -NoNewline; Start-Sleep -Seconds 300"
-		);
-		let mut command = CommandWrap::with_new("powershell.exe", |command| {
-			command.args(["-NoProfile", "-NonInteractive", "-Command", &script]);
+		let mut command = CommandWrap::with_new(std::env::current_exe()?, |command| {
+			command
+				.args([
+					"--ignored",
+					"--exact",
+					concat!(module_path!(), "::descendant_parent"),
+					"--nocapture",
+				])
+				.stdout(Stdio::piped())
+				.stderr(Stdio::piped());
 		});
 		match order {
 			Order::KillOnDropFirst => {
@@ -110,8 +158,8 @@ async fn job_detects_kill_on_drop_in_both_orders() -> Result<()> {
 			}
 		}
 
-		let child = command.spawn()?;
-		let pid = descendant_pid(&pid_file).await?;
+		let mut child = command.spawn()?;
+		let pid = descendant_pid(child.as_mut()).await?;
 		let guard = ProcessGuard::open(pid)?;
 		drop(child);
 		wait_for_process_exit(guard.handle()).await?;

--- a/tests/tokio_windows/job_object_kill_on_drop.rs
+++ b/tests/tokio_windows/job_object_kill_on_drop.rs
@@ -1,0 +1,121 @@
+use std::{fs::read_to_string, io::ErrorKind, time::Instant};
+
+use tempfile::NamedTempFile;
+use windows::Win32::{
+	Foundation::{CloseHandle, HANDLE, WAIT_FAILED, WAIT_OBJECT_0},
+	System::Threading::{
+		OpenProcess, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, TerminateProcess, WaitForSingleObject,
+	},
+};
+
+use super::prelude::*;
+
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+const EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy)]
+enum Order {
+	KillOnDropFirst,
+	JobObjectFirst,
+}
+
+struct ProcessGuard(Option<HANDLE>);
+
+impl ProcessGuard {
+	fn open(pid: u32) -> Result<Self> {
+		let handle = unsafe { OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_TERMINATE, false, pid) }
+			.map_err(std::io::Error::other)?;
+		Ok(Self(Some(handle)))
+	}
+
+	fn handle(&self) -> HANDLE {
+		self.0.expect("the process guard must still be armed")
+	}
+
+	fn disarm(mut self) -> Result<()> {
+		if let Some(handle) = self.0.take() {
+			unsafe { CloseHandle(handle) }?;
+		}
+		Ok(())
+	}
+}
+
+impl Drop for ProcessGuard {
+	fn drop(&mut self) {
+		if let Some(handle) = self.0.take() {
+			unsafe { TerminateProcess(handle, 1) }.ok();
+			unsafe { CloseHandle(handle) }.ok();
+		}
+	}
+}
+
+async fn descendant_pid(file: &NamedTempFile) -> Result<u32> {
+	let deadline = Instant::now() + STARTUP_TIMEOUT;
+	loop {
+		match read_to_string(file.path()) {
+			Ok(contents) if !contents.trim().is_empty() => {
+				return contents.trim().parse().map_err(std::io::Error::other);
+			}
+			Ok(_) => {}
+			Err(error) if error.kind() == ErrorKind::NotFound => {}
+			Err(error) => return Err(error),
+		}
+		if Instant::now() >= deadline {
+			return Err(std::io::Error::new(
+				ErrorKind::TimedOut,
+				"descendant pid was not written",
+			));
+		}
+		sleep(Duration::from_millis(10)).await;
+	}
+}
+
+async fn wait_for_process_exit(handle: HANDLE) -> Result<()> {
+	let deadline = Instant::now() + EXIT_TIMEOUT;
+	loop {
+		let wait = unsafe { WaitForSingleObject(handle, 0) };
+		if wait == WAIT_OBJECT_0 {
+			return Ok(());
+		}
+		if wait == WAIT_FAILED {
+			return Err(std::io::Error::last_os_error());
+		}
+		if Instant::now() >= deadline {
+			return Err(std::io::Error::new(
+				ErrorKind::TimedOut,
+				"descendant survived dropping the job",
+			));
+		}
+		sleep(Duration::from_millis(10)).await;
+	}
+}
+
+#[tokio::test]
+async fn job_detects_kill_on_drop_in_both_orders() -> Result<()> {
+	for order in [Order::KillOnDropFirst, Order::JobObjectFirst] {
+		let pid_file = NamedTempFile::new()?;
+		let path = pid_file.path().display().to_string().replace('\'', "''");
+		let script = format!(
+			"$child = Start-Process powershell.exe -ArgumentList @('-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 300') -PassThru; Set-Content -LiteralPath '{path}' -Value $child.Id -NoNewline; Start-Sleep -Seconds 300"
+		);
+		let mut command = CommandWrap::with_new("powershell.exe", |command| {
+			command.args(["-NoProfile", "-NonInteractive", "-Command", &script]);
+		});
+		match order {
+			Order::KillOnDropFirst => {
+				command.wrap(KillOnDrop).wrap(JobObject);
+			}
+			Order::JobObjectFirst => {
+				command.wrap(JobObject).wrap(KillOnDrop);
+			}
+		}
+
+		let child = command.spawn()?;
+		let pid = descendant_pid(&pid_file).await?;
+		let guard = ProcessGuard::open(pid)?;
+		drop(child);
+		wait_for_process_exit(guard.handle()).await?;
+		guard.disarm()?;
+	}
+	Ok(())
+}

--- a/tests/tokio_windows/mod.rs
+++ b/tests/tokio_windows/mod.rs
@@ -10,11 +10,18 @@ mod prelude {
 	pub const DIE_TIME: Duration = Duration::from_millis(1000);
 }
 
+#[cfg(all(feature = "creation-flags", feature = "job-object"))]
+mod creation_flags_job_object;
 mod id_same_as_inner;
 mod inner_read_stdout;
 mod into_inner_write_stdin;
+#[cfg(all(feature = "job-object", feature = "kill-on-drop"))]
+mod job_object_kill_on_drop;
 mod kill_and_try_wait;
 mod try_wait_after_die;
 mod wait_after_die;
 mod wait_twice;
 mod wait_with_output;
+#[cfg(all(feature = "creation-flags", feature = "job-object"))]
+#[path = "../support/windows_thread.rs"]
+mod windows_thread;

--- a/tests/wrapper_hooks.rs
+++ b/tests/wrapper_hooks.rs
@@ -306,7 +306,7 @@ macro_rules! wrapper_hook_tests {
 				match failure {
 					Failure::Error => assert_eq!(
 						spawn()
-							.expect_err("the first hook invocation must fail")
+							.expect_err("FailOnce is guaranteed to fail its first hook invocation")
 							.to_string(),
 						"fail once"
 					),
@@ -323,7 +323,9 @@ macro_rules! wrapper_hook_tests {
 						events.lock().unwrap().push(RecoveryEvent::Spawn);
 						command.spawn()
 					})
-					.expect("the restored command and wrappers must be reusable");
+					.expect(
+						"state restoration guarantees that the command and wrappers remain reusable",
+					);
 				wait_for_exit(child);
 				assert_eq!(*events.lock().unwrap(), retry_events());
 			}
@@ -387,9 +389,13 @@ macro_rules! wrapper_hook_tests {
 				let mut command = command();
 				let error = command
 					.spawn_with(|_| Err(io::Error::other("spawner failed")))
-					.expect_err("the spawner must fail");
+					.expect_err("the test spawner is guaranteed to fail");
 				assert_eq!(error.to_string(), "spawner failed");
-				wait_for_exit(command.spawn().expect("the command must be restored"));
+				wait_for_exit(
+					command
+						.spawn()
+						.expect("state restoration guarantees that the command remains reusable"),
+				);
 			}
 
 			#[test]
@@ -403,7 +409,11 @@ macro_rules! wrapper_hook_tests {
 					});
 				}));
 				assert!(panic.is_err());
-				wait_for_exit(command.spawn().expect("the command must be restored"));
+				wait_for_exit(
+					command
+						.spawn()
+						.expect("state restoration guarantees that the command remains reusable"),
+				);
 			}
 		}
 	};

--- a/tests/wrapper_hooks.rs
+++ b/tests/wrapper_hooks.rs
@@ -1,0 +1,437 @@
+#![cfg(all(any(feature = "std", feature = "tokio1"), any(unix, windows)))]
+
+macro_rules! wrapper_hook_tests {
+	(
+		$module:ident,
+		$command:path,
+		$child:path,
+		$command_wrap:path,
+		$command_wrapper:path,
+		$child_wrapper:path,
+		$runtime:expr
+	) => {
+		mod $module {
+			use std::{
+				io,
+				panic::{AssertUnwindSafe, catch_unwind},
+				sync::{Arc, Mutex},
+				thread::sleep,
+				time::{Duration, Instant},
+			};
+
+			use $child as Child;
+			use $child_wrapper as ChildWrapper;
+			use $command as Command;
+			use $command_wrap as CommandWrap;
+			use $command_wrapper as CommandWrapper;
+
+			const EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+			#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+			enum Phase {
+				Pre,
+				Post,
+				Wrap,
+			}
+
+			#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+			enum VisibilityEvent {
+				First(Phase),
+				Second(Phase),
+				Spawn,
+			}
+
+			#[derive(Debug)]
+			struct First(Arc<Mutex<Vec<VisibilityEvent>>>);
+
+			impl First {
+				fn observe(&self, phase: Phase, core: &CommandWrap) {
+					assert!(core.has_wrap::<Self>());
+					assert!(core.get_wrap::<Self>().is_none());
+					assert!(core.has_wrap::<Second>());
+					assert!(core.get_wrap::<Second>().is_some());
+					self.0.lock().unwrap().push(VisibilityEvent::First(phase));
+				}
+			}
+
+			impl CommandWrapper for First {
+				fn pre_spawn(
+					&mut self,
+					_command: &mut Command,
+					core: &CommandWrap,
+				) -> io::Result<()> {
+					self.observe(Phase::Pre, core);
+					Ok(())
+				}
+
+				fn post_spawn(
+					&mut self,
+					_command: &mut Command,
+					_child: &mut Child,
+					core: &CommandWrap,
+				) -> io::Result<()> {
+					self.observe(Phase::Post, core);
+					Ok(())
+				}
+
+				fn wrap_child(
+					&mut self,
+					child: Box<dyn ChildWrapper>,
+					core: &CommandWrap,
+				) -> io::Result<Box<dyn ChildWrapper>> {
+					self.observe(Phase::Wrap, core);
+					Ok(child)
+				}
+			}
+
+			#[derive(Debug)]
+			struct Second(Arc<Mutex<Vec<VisibilityEvent>>>);
+
+			impl Second {
+				fn observe(&self, phase: Phase, core: &CommandWrap) {
+					assert!(core.has_wrap::<Self>());
+					assert!(core.get_wrap::<Self>().is_none());
+					assert!(core.has_wrap::<First>());
+					assert!(core.get_wrap::<First>().is_some());
+					self.0.lock().unwrap().push(VisibilityEvent::Second(phase));
+				}
+			}
+
+			impl CommandWrapper for Second {
+				fn pre_spawn(
+					&mut self,
+					_command: &mut Command,
+					core: &CommandWrap,
+				) -> io::Result<()> {
+					self.observe(Phase::Pre, core);
+					Ok(())
+				}
+
+				fn post_spawn(
+					&mut self,
+					_command: &mut Command,
+					_child: &mut Child,
+					core: &CommandWrap,
+				) -> io::Result<()> {
+					self.observe(Phase::Post, core);
+					Ok(())
+				}
+
+				fn wrap_child(
+					&mut self,
+					child: Box<dyn ChildWrapper>,
+					core: &CommandWrap,
+				) -> io::Result<Box<dyn ChildWrapper>> {
+					self.observe(Phase::Wrap, core);
+					Ok(child)
+				}
+			}
+
+			#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+			enum RecoveryEvent {
+				Failing(Phase),
+				Peer(Phase),
+				Spawn,
+			}
+
+			#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+			enum Failure {
+				Error,
+				Panic,
+			}
+
+			#[derive(Debug)]
+			struct FailOnce {
+				phase: Phase,
+				failure: Failure,
+				failed: bool,
+				events: Arc<Mutex<Vec<RecoveryEvent>>>,
+			}
+
+			impl FailOnce {
+				fn visit(&mut self, phase: Phase, core: &CommandWrap) -> io::Result<()> {
+					assert!(core.has_wrap::<Self>());
+					assert!(core.get_wrap::<Self>().is_none());
+					assert!(core.has_wrap::<Peer>());
+					assert!(core.get_wrap::<Peer>().is_some());
+					self.events
+						.lock()
+						.unwrap()
+						.push(RecoveryEvent::Failing(phase));
+
+					if self.phase != phase || self.failed {
+						return Ok(());
+					}
+
+					self.failed = true;
+					match self.failure {
+						Failure::Error => Err(io::Error::other("fail once")),
+						Failure::Panic => panic!("fail once"),
+					}
+				}
+			}
+
+			impl CommandWrapper for FailOnce {
+				fn pre_spawn(
+					&mut self,
+					_command: &mut Command,
+					core: &CommandWrap,
+				) -> io::Result<()> {
+					self.visit(Phase::Pre, core)
+				}
+
+				fn post_spawn(
+					&mut self,
+					_command: &mut Command,
+					_child: &mut Child,
+					core: &CommandWrap,
+				) -> io::Result<()> {
+					self.visit(Phase::Post, core)
+				}
+
+				fn wrap_child(
+					&mut self,
+					child: Box<dyn ChildWrapper>,
+					core: &CommandWrap,
+				) -> io::Result<Box<dyn ChildWrapper>> {
+					self.visit(Phase::Wrap, core)?;
+					Ok(child)
+				}
+			}
+
+			#[derive(Debug)]
+			struct Peer(Arc<Mutex<Vec<RecoveryEvent>>>);
+
+			impl Peer {
+				fn observe(&self, phase: Phase, core: &CommandWrap) {
+					assert!(core.has_wrap::<Self>());
+					assert!(core.get_wrap::<Self>().is_none());
+					assert!(core.has_wrap::<FailOnce>());
+					assert!(core.get_wrap::<FailOnce>().is_some());
+					self.0.lock().unwrap().push(RecoveryEvent::Peer(phase));
+				}
+			}
+
+			impl CommandWrapper for Peer {
+				fn pre_spawn(
+					&mut self,
+					_command: &mut Command,
+					core: &CommandWrap,
+				) -> io::Result<()> {
+					self.observe(Phase::Pre, core);
+					Ok(())
+				}
+
+				fn post_spawn(
+					&mut self,
+					_command: &mut Command,
+					_child: &mut Child,
+					core: &CommandWrap,
+				) -> io::Result<()> {
+					self.observe(Phase::Post, core);
+					Ok(())
+				}
+
+				fn wrap_child(
+					&mut self,
+					child: Box<dyn ChildWrapper>,
+					core: &CommandWrap,
+				) -> io::Result<Box<dyn ChildWrapper>> {
+					self.observe(Phase::Wrap, core);
+					Ok(child)
+				}
+			}
+
+			fn runtime() -> Option<tokio::runtime::Runtime> {
+				$runtime
+			}
+
+			fn command() -> CommandWrap {
+				#[cfg(unix)]
+				return CommandWrap::with_new("sh", |command| {
+					command.args(["-c", "exit 0"]);
+				});
+
+				#[cfg(windows)]
+				return CommandWrap::with_new("cmd.exe", |command| {
+					command.args(["/D", "/S", "/C", "exit /b 0"]);
+				});
+			}
+
+			fn wait_for_exit(mut child: Box<dyn ChildWrapper>) {
+				let deadline = Instant::now() + EXIT_TIMEOUT;
+				loop {
+					if child.try_wait().unwrap().is_some() {
+						return;
+					}
+					assert!(
+						Instant::now() < deadline,
+						"child did not exit before timeout"
+					);
+					sleep(Duration::from_millis(10));
+				}
+			}
+
+			fn retry_events() -> Vec<RecoveryEvent> {
+				vec![
+					RecoveryEvent::Failing(Phase::Pre),
+					RecoveryEvent::Peer(Phase::Pre),
+					RecoveryEvent::Spawn,
+					RecoveryEvent::Failing(Phase::Post),
+					RecoveryEvent::Peer(Phase::Post),
+					RecoveryEvent::Failing(Phase::Wrap),
+					RecoveryEvent::Peer(Phase::Wrap),
+				]
+			}
+
+			fn recover_after(failure: Failure, phase: Phase) {
+				let events = Arc::new(Mutex::new(Vec::new()));
+				let mut command = command();
+				command
+					.wrap(FailOnce {
+						phase,
+						failure,
+						failed: false,
+						events: Arc::clone(&events),
+					})
+					.wrap(Peer(Arc::clone(&events)));
+
+				let mut spawn = || {
+					command.spawn_with(|command| {
+						events.lock().unwrap().push(RecoveryEvent::Spawn);
+						command.spawn()
+					})
+				};
+
+				match failure {
+					Failure::Error => assert_eq!(
+						spawn()
+							.expect_err("the first hook invocation must fail")
+							.to_string(),
+						"fail once"
+					),
+					Failure::Panic => assert!(catch_unwind(AssertUnwindSafe(spawn)).is_err()),
+				}
+
+				assert!(command.has_wrap::<FailOnce>());
+				assert!(command.get_wrap::<FailOnce>().unwrap().failed);
+				assert!(command.get_wrap::<Peer>().is_some());
+
+				events.lock().unwrap().clear();
+				let child = command
+					.spawn_with(|command| {
+						events.lock().unwrap().push(RecoveryEvent::Spawn);
+						command.spawn()
+					})
+					.expect("the restored command and wrappers must be reusable");
+				wait_for_exit(child);
+				assert_eq!(*events.lock().unwrap(), retry_events());
+			}
+
+			#[test]
+			fn peers_are_visible_and_hooks_keep_registration_order() {
+				let runtime = runtime();
+				let _runtime_guard = runtime.as_ref().map(tokio::runtime::Runtime::enter);
+				let events = Arc::new(Mutex::new(Vec::new()));
+				let mut command = command();
+				command
+					.wrap(First(Arc::clone(&events)))
+					.wrap(Second(Arc::clone(&events)));
+
+				let child = command
+					.spawn_with(|command| {
+						events.lock().unwrap().push(VisibilityEvent::Spawn);
+						command.spawn()
+					})
+					.unwrap();
+				wait_for_exit(child);
+
+				assert_eq!(
+					*events.lock().unwrap(),
+					vec![
+						VisibilityEvent::First(Phase::Pre),
+						VisibilityEvent::Second(Phase::Pre),
+						VisibilityEvent::Spawn,
+						VisibilityEvent::First(Phase::Post),
+						VisibilityEvent::Second(Phase::Post),
+						VisibilityEvent::First(Phase::Wrap),
+						VisibilityEvent::Second(Phase::Wrap),
+					]
+				);
+				assert!(command.get_wrap::<First>().is_some());
+				assert!(command.get_wrap::<Second>().is_some());
+			}
+
+			#[test]
+			fn restores_each_hook_after_error() {
+				let runtime = runtime();
+				let _runtime_guard = runtime.as_ref().map(tokio::runtime::Runtime::enter);
+				for phase in [Phase::Pre, Phase::Post, Phase::Wrap] {
+					recover_after(Failure::Error, phase);
+				}
+			}
+
+			#[test]
+			fn restores_each_hook_after_panic() {
+				let runtime = runtime();
+				let _runtime_guard = runtime.as_ref().map(tokio::runtime::Runtime::enter);
+				for phase in [Phase::Pre, Phase::Post, Phase::Wrap] {
+					recover_after(Failure::Panic, phase);
+				}
+			}
+
+			#[test]
+			fn restores_command_after_spawner_error() {
+				let runtime = runtime();
+				let _runtime_guard = runtime.as_ref().map(tokio::runtime::Runtime::enter);
+				let mut command = command();
+				let error = command
+					.spawn_with(|_| Err(io::Error::other("spawner failed")))
+					.expect_err("the spawner must fail");
+				assert_eq!(error.to_string(), "spawner failed");
+				wait_for_exit(command.spawn().expect("the command must be restored"));
+			}
+
+			#[test]
+			fn restores_command_after_spawner_panic() {
+				let runtime = runtime();
+				let _runtime_guard = runtime.as_ref().map(tokio::runtime::Runtime::enter);
+				let mut command = command();
+				let panic = catch_unwind(AssertUnwindSafe(|| {
+					let _ = command.spawn_with(|_| -> io::Result<Child> {
+						panic!("spawner failed");
+					});
+				}));
+				assert!(panic.is_err());
+				wait_for_exit(command.spawn().expect("the command must be restored"));
+			}
+		}
+	};
+}
+
+#[cfg(feature = "std")]
+wrapper_hook_tests!(
+	std_frontend,
+	std::process::Command,
+	std::process::Child,
+	process_wrap::std::CommandWrap,
+	process_wrap::std::CommandWrapper,
+	process_wrap::std::ChildWrapper,
+	None
+);
+
+#[cfg(feature = "tokio1")]
+wrapper_hook_tests!(
+	tokio_frontend,
+	tokio::process::Command,
+	tokio::process::Child,
+	process_wrap::tokio::CommandWrap,
+	process_wrap::tokio::CommandWrapper,
+	process_wrap::tokio::ChildWrapper,
+	Some(
+		tokio::runtime::Builder::new_current_thread()
+			.enable_all()
+			.build()
+			.unwrap()
+	)
+);


### PR DESCRIPTION
This fixes wrapper composition. Basically to do composition properly each hook needs to be removed from the stack while it's active, while preserving its position, it turns out this isn't that easy and I messed it up a bunch; this fixes that. The most important consequence is that, unlike every other workaround I'd tried, this completely removes the requirement to order `JobObject` and `CreationFlags` in a particular way for things to work.

- retain every wrapper registration and its insertion position while one hook is active
- keep peer wrappers query-able from `pre_spawn`, `post_spawn`, and `wrap_child`
- restore wrappers and commands after success, errors, and unwinds so commands remain reusable
- compose `CreationFlags` and `JobObject` in either registration order without losing flags or resuming explicitly suspended processes
- preserve Tokio `KillOnDrop` discovery and behaviour

Fixes #19
Fixes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
