### PR TITLE
ci: check common combinations of features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,13 @@
 name: Test
+
 on:
   pull_request:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -25,7 +29,9 @@ jobs:
     runs-on: "${{ matrix.platform }}-latest"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Configure Rust
         run: |
@@ -34,23 +40,119 @@ jobs:
           rustup default ${{ matrix.toolchain }}
           rustup component add clippy
 
-      - uses: Swatinem/rust-cache@v2
-
       - run: tests/multiproc_helper.rs 1 1
-      - run: cargo test --features ${{ matrix.features }} --all-targets
-      - run: cargo clippy --features ${{ matrix.features }}
 
-  formatting:
-    name: Fmt check
+      - name: Test defaults plus frontend
+        run: cargo test --locked --features ${{ matrix.features }} --all-targets
+
+      - name: Test frontend without default wrappers
+        if: matrix.toolchain == 'stable'
+        run: cargo test --locked --no-default-features --features ${{ matrix.features }} --all-targets
+
+      - run: cargo clippy --locked --features ${{ matrix.features }}
+
+  no-default-features:
+    name: Check without any features
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Configure Rust
         run: |
           rustup toolchain install --profile minimal --no-self-update stable
           rustup default stable
 
-      - run: cargo fmt --check
+      - run: cargo check --locked --no-default-features --lib
 
+  all-features:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - macos
+          - ubuntu
+          - windows
+
+    name: "Test all features on ${{ matrix.platform }}"
+    runs-on: "${{ matrix.platform }}-latest"
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Configure Rust
+        run: |
+          rustup toolchain install --profile minimal --no-self-update nightly
+          rustup toolchain install --profile minimal --no-self-update stable
+          rustup default stable
+
+      - run: tests/multiproc_helper.rs 1 1
+      - run: cargo test --locked --all-features --all-targets
+
+  rustdoc:
+    name: Rustdoc
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Configure Rust
+        run: |
+          rustup toolchain install --profile minimal --no-self-update stable
+          rustup default stable
+
+      - name: Build documentation with warnings denied
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --locked --all-features --no-deps
+
+  semver:
+    name: Semver against PR base
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure Rust
+        run: |
+          rustup toolchain install --profile minimal --no-self-update stable
+          rustup default stable
+
+      - name: Install cargo-semver-checks
+        run: cargo install --locked --version 0.50.0 cargo-semver-checks
+
+      - name: Check API compatibility
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          printf 'Comparing against %s at %s\n' "$BASE_REF" "$BASE_SHA"
+          git cat-file -e "${BASE_SHA}^{commit}"
+          cargo semver-checks check-release --all-features --baseline-rev "$BASE_SHA"
+
+  formatting:
+    name: Fmt check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Configure Rust
+        run: |
+          rustup toolchain install --profile minimal --no-self-update stable
+          rustup default stable
+          rustup component add rustfmt
+
+      - run: cargo fmt --check

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ CommandWrap::with_new("watch", |command| { command.arg("ls"); })
   .spawn()?;
 ```
 
-When both `CreationFlags` and `JobObject` are used together, either:
-- `CreationFlags` must come first, or
-- `CreationFlags` must include `CREATE_SUSPENDED`
+`CreationFlags` and `JobObject` may be registered in either order. `JobObject` preserves every
+requested flag, temporarily adds `CREATE_SUSPENDED` while assigning the process, and resumes it
+after assignment unless the caller explicitly requested `CREATE_SUSPENDED`.
 
 ### Process group
 
@@ -183,9 +183,9 @@ CommandWrap::with_new("watch", |command| { command.arg("ls"); })
   .spawn()?;
 ```
 
-When both `CreationFlags` and `JobObject` are used together, either:
-- `CreationFlags` must come first, or
-- `CreationFlags` must include `CREATE_SUSPENDED`
+`CreationFlags` and `JobObject` may be registered in either order. `JobObject` preserves every
+requested flag, temporarily adds `CREATE_SUSPENDED` while assigning the process, and resumes it
+after assignment unless the caller explicitly requested `CREATE_SUSPENDED`.
 
 ### Kill on drop
 
@@ -223,9 +223,11 @@ That's right, all member methods are optional.
 The trait provides extension or hook points into the lifecycle of a `Command`:
 
 - **`fn extend(&mut self, other: Box<dyn CommandWrapper>)`** is called if `.wrap(YourWrapper)`
-  is done twice. Only one of a wrapper type can exist, so this gives the opportunity to incorporate
-  all or part of the second wrapper instance into the first. By default, this does nothing (ie only
-  the first registered wrapper instance of a type does anything).
+  is done twice. Only one of a wrapper type can exist, so this lets the stored instance react to the
+  second registration. `CommandWrap` passes the same concrete type for `self` and `other`, but
+  `CommandWrapper` exposes no downcast operation, so implementations cannot inspect type-specific
+  fields on `other`. By default, this does nothing (ie only the first registered wrapper instance of
+  a type does anything).
 
 - **`fn pre_spawn(&mut self, command: &mut Command, core: &CommandWrap)`** is called before the
   command is spawned, and gives mutable access to it. It also gives mutable access to the wrapper

--- a/cliff.toml
+++ b/cliff.toml
@@ -9,7 +9,7 @@ body = """
 ---
 {% if version %}\
     {% if previous.version %}\
-        ## [{{ version | trim_start_matches(pat="v") }}]($REPO/compare/{{ previous.version }}..{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+        ## [{{ version | trim_start_matches(pat="v") }}]($REPO/compare/v{{ previous.version | trim_start_matches(pat="v") }}..v{{ version | trim_start_matches(pat="v") }}) - {{ timestamp | date(format="%Y-%m-%d") }}
     {% else %}\
         ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
     {% endif %}\

--- a/src/generic_wrap.rs
+++ b/src/generic_wrap.rs
@@ -73,9 +73,10 @@ macro_rules! Wrap {
 			/// called.
 			///
 			/// Only one wrapper of a given type can be applied to a command. If `wrap` is called
-			/// twice with the same type, the existing wrapper will have its `extend` hook called,
-			/// which gives it a chance to absorb the new wrapper. If it does not, the _new_ wrapper
-			/// will be silently discarded.
+			/// twice with the same type, the existing wrapper will have its `extend` hook called
+			/// with the new wrapper. The hook can react through the `CommandWrapper` interface, but
+			/// cannot downcast the new wrapper or inspect its type-specific fields. If the hook does
+			/// nothing, the _new_ wrapper is silently discarded.
 			///
 			/// Returns `&mut self` for chaining.
 			pub fn wrap<W: CommandWrapper + 'static>(&mut self, wrapper: W) -> &mut Self {
@@ -265,15 +266,15 @@ macro_rules! Wrap {
 		pub trait CommandWrapper: ::std::fmt::Debug + Send + Sync {
 			/// Called on a first instance if a second of the same type is added.
 			///
-			/// Only one of a wrapper type can exist within a Wrap at a time. The default behaviour
-			/// is to silently discard any further invocations. However in some cases it might be
-			/// useful to merge the two. This method is called on the instance already stored within
-			/// the Wrap, with the new instance.
+			/// Only one wrapper of a given type can exist within a Wrap at a time. The default
+			/// behaviour is to discard further instances. This hook lets the stored instance react
+			/// to another registration.
 			///
-			/// The `other` argument is guaranteed by process-wrap to be of the same type as `self`,
-			/// so you can downcast it with `.unwrap()` and not panic. Note that it is possible for
-			/// other code to use this trait and not guarantee this, so you should still panic if
-			/// downcasting fails, instead of using unchecked downcasting and unleashing UB.
+			/// process-wrap passes an `other` value with the same concrete type as `self`. However,
+			/// `CommandWrapper` does not expose a downcast operation, so an implementation can
+			/// mutate `self` in response but cannot inspect type-specific fields on `other`. Do not
+			/// use unchecked downcasting based on this invariant: callers outside process-wrap are
+			/// not required to preserve it.
 			///
 			/// Default impl: no-op.
 			fn extend(&mut self, _other: Box<dyn CommandWrapper>) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,9 +128,11 @@
 //! The trait provides extension or hook points into the lifecycle of a `Command`:
 //!
 //! - **`fn extend(&mut self, other: Box<dyn CommandWrapper>)`** is called if
-//!   `.wrap(YourWrapper)` is done twice. Only one of a wrapper type can exist, so this gives the
-//!   opportunity to incorporate all or part of the second wrapper instance into the first. By
-//!   default, this does nothing (ie only the first registered wrapper instance of a type applies).
+//!   `.wrap(YourWrapper)` is done twice. Only one of a wrapper type can exist, so this lets the
+//!   stored instance react to the second registration. `CommandWrap` passes the same concrete type
+//!   for `self` and `other`, but `CommandWrapper` exposes no downcast operation, so implementations
+//!   cannot inspect type-specific fields on `other`. By default, this does nothing (ie only the first
+//!   registered wrapper instance of a type applies).
 //!
 //! - **`fn pre_spawn(&mut self, command: &mut Command, core: &CommandWrap)`** is called before
 //!   the command is spawned, and gives mutable access to it. It also gives mutable access to the

--- a/tests/std_unix/id_same_as_inner.rs
+++ b/tests/std_unix/id_same_as_inner.rs
@@ -12,6 +12,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group() -> Result<()> {
 	let child = CommandWrap::with_new("echo", |command| {
@@ -25,6 +26,7 @@ fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session() -> Result<()> {
 	let child = CommandWrap::with_new("echo", |command| {

--- a/tests/std_unix/inner_read_stdout.rs
+++ b/tests/std_unix/inner_read_stdout.rs
@@ -16,6 +16,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {
@@ -33,6 +34,7 @@ fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {

--- a/tests/std_unix/into_inner_write_stdin.rs
+++ b/tests/std_unix/into_inner_write_stdin.rs
@@ -23,6 +23,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group() -> Result<()> {
 	let mut child = unsafe {
@@ -47,6 +48,7 @@ fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session() -> Result<()> {
 	let mut child = unsafe {

--- a/tests/std_unix/kill_and_try_wait.rs
+++ b/tests/std_unix/kill_and_try_wait.rs
@@ -18,6 +18,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {
@@ -41,6 +42,7 @@ fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {

--- a/tests/std_unix/multiproc_linux.rs
+++ b/tests/std_unix/multiproc_linux.rs
@@ -2,6 +2,7 @@
 
 use super::prelude::*;
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group_kill_leader() -> Result<()> {
 	let mut leader = CommandWrap::with_new("tests/multiproc_helper.rs", |command| {
@@ -44,6 +45,7 @@ fn process_group_kill_leader() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group_kill_group() -> Result<()> {
 	let mut leader = CommandWrap::with_new("tests/multiproc_helper.rs", |command| {
@@ -87,6 +89,7 @@ fn process_group_kill_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session_kill_leader() -> Result<()> {
 	let mut leader = CommandWrap::with_new("tests/multiproc_helper.rs", |command| {
@@ -129,6 +132,7 @@ fn process_session_kill_leader() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session_kill_group() -> Result<()> {
 	let mut leader = CommandWrap::with_new("tests/multiproc_helper.rs", |command| {

--- a/tests/std_unix/signals.rs
+++ b/tests/std_unix/signals.rs
@@ -18,6 +18,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {
@@ -37,6 +38,7 @@ fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {

--- a/tests/std_unix/try_wait_after_die.rs
+++ b/tests/std_unix/try_wait_after_die.rs
@@ -14,6 +14,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {
@@ -29,6 +30,7 @@ fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {

--- a/tests/std_unix/try_wait_twice_after_sigterm.rs
+++ b/tests/std_unix/try_wait_twice_after_sigterm.rs
@@ -18,6 +18,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {
@@ -37,6 +38,7 @@ fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {

--- a/tests/std_unix/wait_after_die.rs
+++ b/tests/std_unix/wait_after_die.rs
@@ -14,6 +14,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {
@@ -29,6 +30,7 @@ fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {

--- a/tests/std_unix/wait_twice.rs
+++ b/tests/std_unix/wait_twice.rs
@@ -16,6 +16,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {
@@ -33,6 +34,7 @@ fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {

--- a/tests/std_unix/wait_twice_after_sigterm.rs
+++ b/tests/std_unix/wait_twice_after_sigterm.rs
@@ -19,6 +19,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {
@@ -39,6 +40,7 @@ fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {

--- a/tests/std_unix/wait_with_output.rs
+++ b/tests/std_unix/wait_with_output.rs
@@ -14,6 +14,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[test]
 fn process_group() -> Result<()> {
 	let child = CommandWrap::with_new("echo", |command| {
@@ -29,6 +30,7 @@ fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[test]
 fn process_session() -> Result<()> {
 	let child = CommandWrap::with_new("echo", |command| {

--- a/tests/std_windows/id_same_as_inner.rs
+++ b/tests/std_windows/id_same_as_inner.rs
@@ -12,6 +12,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[test]
 fn job_object() -> Result<()> {
 	let child = CommandWrap::with_new("powershell.exe", |command| {

--- a/tests/std_windows/inner_read_stdout.rs
+++ b/tests/std_windows/inner_read_stdout.rs
@@ -16,6 +16,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[test]
 fn job_object() -> Result<()> {
 	let mut child = CommandWrap::with_new("powershell.exe", |command| {

--- a/tests/std_windows/into_inner_write_stdin.rs
+++ b/tests/std_windows/into_inner_write_stdin.rs
@@ -24,6 +24,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[test]
 fn job_object() -> Result<()> {
 	let mut child = CommandWrap::with_new("findstr", |command| {

--- a/tests/std_windows/kill_and_try_wait.rs
+++ b/tests/std_windows/kill_and_try_wait.rs
@@ -18,6 +18,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[test]
 fn job_object() -> Result<()> {
 	let mut child = CommandWrap::with_new("powershell.exe", |command| {

--- a/tests/std_windows/try_wait_after_die.rs
+++ b/tests/std_windows/try_wait_after_die.rs
@@ -32,6 +32,7 @@ fn nowrap() -> Result<()> {
 	assert_exits(child.as_mut())
 }
 
+#[cfg(feature = "job-object")]
 #[test]
 fn job_object() -> Result<()> {
 	let mut child = command().wrap(JobObject).spawn()?;

--- a/tests/std_windows/wait_after_die.rs
+++ b/tests/std_windows/wait_after_die.rs
@@ -14,6 +14,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[test]
 fn job_object() -> Result<()> {
 	let mut child = CommandWrap::with_new("powershell.exe", |command| {

--- a/tests/std_windows/wait_twice.rs
+++ b/tests/std_windows/wait_twice.rs
@@ -16,6 +16,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[test]
 fn job_object() -> Result<()> {
 	let mut child = CommandWrap::with_new("powershell.exe", |command| {

--- a/tests/std_windows/wait_with_output.rs
+++ b/tests/std_windows/wait_with_output.rs
@@ -14,6 +14,7 @@ fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[test]
 fn job_object() -> Result<()> {
 	let child = CommandWrap::with_new("powershell.exe", |command| {

--- a/tests/tokio_unix/id_same_as_inner.rs
+++ b/tests/tokio_unix/id_same_as_inner.rs
@@ -12,6 +12,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[tokio::test]
 async fn process_group() -> Result<()> {
 	let child = CommandWrap::with_new("echo", |command| {
@@ -25,6 +26,7 @@ async fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[tokio::test]
 async fn process_session() -> Result<()> {
 	let child = CommandWrap::with_new("echo", |command| {

--- a/tests/tokio_unix/inner_read_stdout.rs
+++ b/tests/tokio_unix/inner_read_stdout.rs
@@ -16,6 +16,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[tokio::test]
 async fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {
@@ -33,6 +34,7 @@ async fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[tokio::test]
 async fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {

--- a/tests/tokio_unix/into_inner_write_stdin.rs
+++ b/tests/tokio_unix/into_inner_write_stdin.rs
@@ -21,6 +21,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[tokio::test]
 async fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("cat", |command| {
@@ -43,6 +44,7 @@ async fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[tokio::test]
 async fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("cat", |command| {

--- a/tests/tokio_unix/kill_and_try_wait.rs
+++ b/tests/tokio_unix/kill_and_try_wait.rs
@@ -18,6 +18,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[tokio::test]
 async fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {
@@ -41,6 +42,7 @@ async fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[tokio::test]
 async fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {

--- a/tests/tokio_unix/multiproc_linux.rs
+++ b/tests/tokio_unix/multiproc_linux.rs
@@ -2,6 +2,7 @@
 
 use super::prelude::*;
 
+#[cfg(all(feature = "kill-on-drop", feature = "process-group"))]
 #[tokio::test]
 async fn process_group_kill_leader() -> Result<()> {
 	let mut leader = CommandWrap::with_new("tests/multiproc_helper.rs", |command| {
@@ -45,6 +46,7 @@ async fn process_group_kill_leader() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(all(feature = "kill-on-drop", feature = "process-group"))]
 #[tokio::test]
 async fn process_group_kill_group() -> Result<()> {
 	let mut leader = CommandWrap::with_new("tests/multiproc_helper.rs", |command| {
@@ -89,6 +91,7 @@ async fn process_group_kill_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
 #[tokio::test]
 async fn process_session_kill_leader() -> Result<()> {
 	let mut leader = CommandWrap::with_new("tests/multiproc_helper.rs", |command| {
@@ -132,6 +135,7 @@ async fn process_session_kill_leader() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
 #[tokio::test]
 async fn process_session_kill_group() -> Result<()> {
 	let mut leader = CommandWrap::with_new("tests/multiproc_helper.rs", |command| {

--- a/tests/tokio_unix/signals.rs
+++ b/tests/tokio_unix/signals.rs
@@ -18,6 +18,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[tokio::test]
 async fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {
@@ -37,6 +38,7 @@ async fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[tokio::test]
 async fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {

--- a/tests/tokio_unix/try_wait_after_die.rs
+++ b/tests/tokio_unix/try_wait_after_die.rs
@@ -14,6 +14,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[tokio::test]
 async fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {
@@ -29,6 +30,7 @@ async fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[tokio::test]
 async fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {

--- a/tests/tokio_unix/try_wait_twice_after_sigterm.rs
+++ b/tests/tokio_unix/try_wait_twice_after_sigterm.rs
@@ -18,6 +18,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[tokio::test]
 async fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {
@@ -37,6 +38,7 @@ async fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[tokio::test]
 async fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {

--- a/tests/tokio_unix/wait_after_die.rs
+++ b/tests/tokio_unix/wait_after_die.rs
@@ -14,6 +14,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[tokio::test]
 async fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {
@@ -29,6 +30,7 @@ async fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[tokio::test]
 async fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {

--- a/tests/tokio_unix/wait_twice.rs
+++ b/tests/tokio_unix/wait_twice.rs
@@ -16,6 +16,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[tokio::test]
 async fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {
@@ -33,6 +34,7 @@ async fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[tokio::test]
 async fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("echo", |command| {

--- a/tests/tokio_unix/wait_twice_after_sigterm.rs
+++ b/tests/tokio_unix/wait_twice_after_sigterm.rs
@@ -19,6 +19,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[tokio::test]
 async fn process_group() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {
@@ -39,6 +40,7 @@ async fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[tokio::test]
 async fn process_session() -> Result<()> {
 	let mut child = CommandWrap::with_new("yes", |command| {

--- a/tests/tokio_unix/wait_with_output.rs
+++ b/tests/tokio_unix/wait_with_output.rs
@@ -14,6 +14,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-group")]
 #[tokio::test]
 async fn process_group() -> Result<()> {
 	let child = CommandWrap::with_new("echo", |command| {
@@ -29,6 +30,7 @@ async fn process_group() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "process-session")]
 #[tokio::test]
 async fn process_session() -> Result<()> {
 	let child = CommandWrap::with_new("echo", |command| {

--- a/tests/tokio_windows/id_same_as_inner.rs
+++ b/tests/tokio_windows/id_same_as_inner.rs
@@ -12,6 +12,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[tokio::test]
 async fn job_object() -> Result<()> {
 	let child = CommandWrap::with_new("powershell.exe", |command| {

--- a/tests/tokio_windows/inner_read_stdout.rs
+++ b/tests/tokio_windows/inner_read_stdout.rs
@@ -16,6 +16,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[tokio::test]
 async fn job_object() -> Result<()> {
 	let mut child = CommandWrap::with_new("powershell.exe", |command| {

--- a/tests/tokio_windows/into_inner_write_stdin.rs
+++ b/tests/tokio_windows/into_inner_write_stdin.rs
@@ -24,6 +24,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[tokio::test]
 async fn job_object() -> Result<()> {
 	let mut child = CommandWrap::with_new("findstr", |command| {

--- a/tests/tokio_windows/kill_and_try_wait.rs
+++ b/tests/tokio_windows/kill_and_try_wait.rs
@@ -18,6 +18,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[tokio::test]
 async fn job_object() -> Result<()> {
 	let mut child = CommandWrap::with_new("powershell.exe", |command| {

--- a/tests/tokio_windows/try_wait_after_die.rs
+++ b/tests/tokio_windows/try_wait_after_die.rs
@@ -32,6 +32,7 @@ async fn nowrap() -> Result<()> {
 	assert_exits(child.as_mut()).await
 }
 
+#[cfg(feature = "job-object")]
 #[tokio::test]
 async fn job_object() -> Result<()> {
 	let mut child = command().wrap(JobObject).spawn()?;

--- a/tests/tokio_windows/wait_after_die.rs
+++ b/tests/tokio_windows/wait_after_die.rs
@@ -14,6 +14,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[tokio::test]
 async fn job_object() -> Result<()> {
 	let mut child = CommandWrap::with_new("powershell.exe", |command| {

--- a/tests/tokio_windows/wait_twice.rs
+++ b/tests/tokio_windows/wait_twice.rs
@@ -16,6 +16,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[tokio::test]
 async fn job_object() -> Result<()> {
 	let mut child = CommandWrap::with_new("powershell.exe", |command| {

--- a/tests/tokio_windows/wait_with_output.rs
+++ b/tests/tokio_windows/wait_with_output.rs
@@ -14,6 +14,7 @@ async fn nowrap() -> Result<()> {
 	Ok(())
 }
 
+#[cfg(feature = "job-object")]
 #[tokio::test]
 async fn job_object() -> Result<()> {
 	let child = CommandWrap::with_new("powershell.exe", |command| {


### PR DESCRIPTION
Previously we only ran the test suite over the default set of features, missing issues with feature-less or feature-full builds in different configurations. While testing every possible combination is a combinatorial explosion, we can at least try more than before.

- check no-default, minimal frontend, and all-feature configurations in CI
- check rustdoc with warnings denied
- perform semver checks against the actual pull-request base SHA
- normalise git-cliff compare links

🤖 Generated with [Claude Code](https://claude.com/claude-code)
