### PR TITLE
feat: replace panicking accessors with fallible ones

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,13 @@
 //!         self.inner
 //!     }
 //!
+//!     #[cfg(windows)]
+//!     fn process_handle(
+//!         &self,
+//!     ) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+//!         self.inner.process_handle()
+//!     }
+//!
 //!     fn wait(&mut self) -> io::Result<ExitStatus> {
 //!         let exit_status = self.inner.wait();
 //!
@@ -397,6 +404,13 @@
 //! #
 //! #     fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
 //! #         self.inner
+//! #     }
+//! #
+//! #     #[cfg(windows)]
+//! #     fn process_handle(
+//! #         &self,
+//! #     ) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+//! #         self.inner.process_handle()
 //! #     }
 //! #
 //! #     fn wait(&mut self) -> io::Result<ExitStatus> {

--- a/src/std/core.rs
+++ b/src/std/core.rs
@@ -4,6 +4,9 @@ use std::{
 	process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, ExitStatus, Output},
 };
 
+#[cfg(windows)]
+use std::os::windows::io::{AsHandle, BorrowedHandle};
+
 #[cfg(unix)]
 use nix::{
 	sys::signal::{Signal, kill},
@@ -17,10 +20,13 @@ crate::generic_wrap::Wrap!(Command, Child, ChildWrapper, |child| child);
 /// This trait exposes most of the functionality of the underlying [`Child`]. It is implemented for
 /// [`Child`] and by wrappers.
 ///
-/// The required methods are `inner`, `inner_mut`, and `into_inner`. That provides access to the
-/// lower layer and ultimately allows the wrappers to be unwrap and the `Child` to be used directly
-/// if necessary. There are convenience `inner_child`, `inner_child_mut` and `into_inner_child`
-/// methods on the trait object.
+/// The required methods are `inner`, `inner_mut`, and `into_inner`. Each non-terminal wrapper must
+/// use them to expose its direct lower layer. A terminal non-native child returns itself from all
+/// three methods. Wrapper chains must otherwise be acyclic and terminate in either a native
+/// [`Child`] or a self-returning non-native child.
+///
+/// The `try_inner_child`, `try_inner_child_mut`, and `try_into_inner_child` convenience methods on
+/// the trait object traverse these layers when access to a native [`Child`] is required.
 ///
 /// It also makes it possible for all the other methods to have default implementations. Some are
 /// direct passthroughs to the lower layers, while others are more complex.
@@ -46,6 +52,13 @@ crate::generic_wrap::Wrap!(Command, Child, ChildWrapper, |child| child);
 ///     fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
 ///         Box::new((*self).0)
 ///     }
+///
+///     #[cfg(windows)]
+///     fn process_handle(
+///         &self,
+///     ) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+///         self.0.process_handle()
+///     }
 /// }
 /// ```
 pub trait ChildWrapper: Any + std::fmt::Debug + Send + Sync {
@@ -61,6 +74,20 @@ pub trait ChildWrapper: Any + std::fmt::Debug + Send + Sync {
 	/// ensure that the wrapped child is in a consistent state when this is called or they are
 	/// dropped, so that this is always safe.
 	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper>;
+
+	/// Borrow the handle for the process represented by this child, if available.
+	///
+	/// This method is only available on Windows. The returned handle cannot outlive the borrow of
+	/// `self`. Transparent child wrappers should override this method and delegate directly to the
+	/// child they own. Terminal custom children which do not represent a native process may retain the
+	/// default implementation.
+	///
+	/// Implementations returning `Some` must return a process handle, rather than another kind of
+	/// Windows object.
+	#[cfg(windows)]
+	fn process_handle(&self) -> Option<BorrowedHandle<'_>> {
+		None
+	}
 
 	/// Obtain a clone if possible.
 	///
@@ -204,6 +231,10 @@ impl ChildWrapper for Child {
 	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
 		self
 	}
+	#[cfg(windows)]
+	fn process_handle(&self) -> Option<BorrowedHandle<'_>> {
+		Some(self.as_handle())
+	}
 	fn stdin(&mut self) -> &mut Option<ChildStdin> {
 		&mut self.stdin
 	}
@@ -243,7 +274,13 @@ impl ChildWrapper for Child {
 	}
 }
 
-impl dyn ChildWrapper {
+const INNER_CHILD_INVARIANT: &str = "ChildWrapper chain did not terminate in std::process::Child";
+
+fn same_child(left: &dyn ChildWrapper, right: &dyn ChildWrapper) -> bool {
+	std::ptr::addr_eq(left, right) && left.type_id() == right.type_id()
+}
+
+impl dyn ChildWrapper + '_ {
 	fn downcast_ref<T: 'static>(&self) -> Option<&T> {
 		(self as &dyn Any).downcast_ref()
 	}
@@ -252,41 +289,123 @@ impl dyn ChildWrapper {
 		self.downcast_ref::<Child>().is_some()
 	}
 
-	/// Obtain a reference to the underlying [`Child`].
-	pub fn inner_child(&self) -> &Child {
+	/// Try to obtain a reference to the underlying native [`Child`].
+	///
+	/// Returns `None` if the wrapper chain terminates in a non-native child.
+	pub fn try_inner_child(&self) -> Option<&Child> {
 		let mut inner = self;
-		while !inner.is_raw_child() {
-			inner = inner.inner();
-		}
+		loop {
+			if let Some(child) = inner.downcast_ref::<Child>() {
+				return Some(child);
+			}
 
-		// UNWRAP: we've just checked that it's Some with is_raw_child()
-		inner.downcast_ref().unwrap()
+			let next = inner.inner();
+			if same_child(inner, next) {
+				return None;
+			}
+			inner = next;
+		}
 	}
 
-	/// Obtain a mutable reference to the underlying [`Child`].
+	/// Try to obtain a mutable reference to the underlying native [`Child`].
 	///
-	/// Modifying the raw child may be unsound depending on the layering of wrappers.
-	pub unsafe fn inner_child_mut(&mut self) -> &mut Child {
+	/// Returns `None` if the wrapper chain terminates in a non-native child.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that using the returned mutable child does not violate invariants
+	/// maintained by any wrapper in the chain.
+	pub unsafe fn try_inner_child_mut(&mut self) -> Option<&mut Child> {
 		let mut inner = self;
-		while !inner.is_raw_child() {
-			inner = inner.inner_mut();
-		}
+		loop {
+			if inner.is_raw_child() {
+				return (inner as &mut dyn Any).downcast_mut();
+			}
 
-		// UNWRAP: we've just checked that with is_raw_child()
-		(inner as &mut dyn Any).downcast_mut().unwrap()
+			let inner_type = (&*inner as &dyn Any).type_id();
+			let inner_ptr = std::ptr::from_mut(inner);
+			let next = inner.inner_mut();
+			if std::ptr::addr_eq(inner_ptr, std::ptr::from_mut(next))
+				&& inner_type == (&*next as &dyn Any).type_id()
+			{
+				return None;
+			}
+			inner = next;
+		}
 	}
 
-	/// Obtain the underlying [`Child`].
+	/// Try to consume the wrapper chain and obtain the underlying native [`Child`].
 	///
-	/// Unwrapping everything may be unsound depending on the state of the wrappers.
-	pub unsafe fn into_inner_child(self: Box<Self>) -> Child {
+	/// If the chain terminates in a non-native child, returns that terminal child without calling its
+	/// `into_inner` method. Wrappers already traversed before reaching it have been consumed.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that removing every traversed wrapper does not violate wrapper
+	/// invariants or bypass required cleanup. This also applies when the method returns `Err`, because
+	/// wrappers above the returned terminal child have already been consumed.
+	pub unsafe fn try_into_inner_child(self: Box<Self>) -> std::result::Result<Child, Box<Self>> {
 		let mut inner = self;
-		while !inner.is_raw_child() {
+		loop {
+			if inner.is_raw_child() {
+				return match (inner as Box<dyn Any>).downcast::<Child>() {
+					Ok(child) => Ok(*child),
+					Err(_) => unreachable!("native child type was checked before downcasting"),
+				};
+			}
+
+			let terminal = {
+				let next = inner.inner();
+				same_child(inner.as_ref(), next)
+			};
+			if terminal {
+				return Err(inner);
+			}
 			inner = inner.into_inner();
 		}
+	}
 
-		// UNWRAP: we've just checked that with is_raw_child()
-		*(inner as Box<dyn Any>).downcast().unwrap()
+	/// Obtain a reference to the underlying native [`Child`].
+	///
+	/// # Panics
+	///
+	/// Panics if the wrapper chain terminates in a non-native child.
+	#[track_caller]
+	pub fn inner_child(&self) -> &Child {
+		self.try_inner_child().expect(INNER_CHILD_INVARIANT)
+	}
+
+	/// Obtain a mutable reference to the underlying native [`Child`].
+	///
+	/// # Panics
+	///
+	/// Panics if the wrapper chain terminates in a non-native child.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that using the returned mutable child does not violate invariants
+	/// maintained by any wrapper in the chain.
+	#[track_caller]
+	pub unsafe fn inner_child_mut(&mut self) -> &mut Child {
+		unsafe { self.try_inner_child_mut() }.expect(INNER_CHILD_INVARIANT)
+	}
+
+	/// Consume the wrapper chain and obtain the underlying native [`Child`].
+	///
+	/// # Panics
+	///
+	/// Panics if the wrapper chain terminates in a non-native child.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that removing every traversed wrapper does not violate wrapper
+	/// invariants or bypass required cleanup.
+	#[track_caller]
+	pub unsafe fn into_inner_child(self: Box<Self>) -> Child {
+		match unsafe { self.try_into_inner_child() } {
+			Ok(child) => child,
+			Err(_) => panic!("{INNER_CHILD_INVARIANT}"),
+		}
 	}
 }
 

--- a/src/std/core.rs
+++ b/src/std/core.rs
@@ -277,8 +277,6 @@ impl ChildWrapper for Child {
 	}
 }
 
-const INNER_CHILD_INVARIANT: &str = "ChildWrapper chain did not terminate in std::process::Child";
-
 fn same_child(left: &dyn ChildWrapper, right: &dyn ChildWrapper) -> bool {
 	std::ptr::addr_eq(left, right) && left.type_id() == right.type_id()
 }
@@ -365,49 +363,6 @@ impl dyn ChildWrapper + '_ {
 				return Err(inner);
 			}
 			inner = inner.into_inner();
-		}
-	}
-
-	/// Obtain a reference to the underlying native [`Child`].
-	///
-	/// # Panics
-	///
-	/// Panics if the wrapper chain terminates in a non-native child.
-	#[track_caller]
-	pub fn inner_child(&self) -> &Child {
-		self.try_inner_child().expect(INNER_CHILD_INVARIANT)
-	}
-
-	/// Obtain a mutable reference to the underlying native [`Child`].
-	///
-	/// # Panics
-	///
-	/// Panics if the wrapper chain terminates in a non-native child.
-	///
-	/// # Safety
-	///
-	/// The caller must ensure that using the returned mutable child does not violate invariants
-	/// maintained by any wrapper in the chain.
-	#[track_caller]
-	pub unsafe fn inner_child_mut(&mut self) -> &mut Child {
-		unsafe { self.try_inner_child_mut() }.expect(INNER_CHILD_INVARIANT)
-	}
-
-	/// Consume the wrapper chain and obtain the underlying native [`Child`].
-	///
-	/// # Panics
-	///
-	/// Panics if the wrapper chain terminates in a non-native child.
-	///
-	/// # Safety
-	///
-	/// The caller must ensure that removing every traversed wrapper does not violate wrapper
-	/// invariants or bypass required cleanup.
-	#[track_caller]
-	pub unsafe fn into_inner_child(self: Box<Self>) -> Child {
-		match unsafe { self.try_into_inner_child() } {
-			Ok(child) => child,
-			Err(_) => panic!("{INNER_CHILD_INVARIANT}"),
 		}
 	}
 }

--- a/src/std/core.rs
+++ b/src/std/core.rs
@@ -20,10 +20,13 @@ crate::generic_wrap::Wrap!(Command, Child, ChildWrapper, |child| child);
 /// This trait exposes most of the functionality of the underlying [`Child`]. It is implemented for
 /// [`Child`] and by wrappers.
 ///
-/// The required methods are `inner`, `inner_mut`, and `into_inner`. Each non-terminal wrapper must
-/// use them to expose its direct lower layer. A terminal non-native child returns itself from all
-/// three methods. Wrapper chains must otherwise be acyclic and terminate in either a native
-/// [`Child`] or a self-returning non-native child.
+/// The required methods are `inner`, `inner_mut`, and `into_inner`. Together they expose each lower
+/// layer, allowing wrappers to be unwrapped and the native [`Child`] to be used directly when
+/// necessary.
+///
+/// Each non-terminal wrapper must use them to expose its direct lower layer. A terminal non-native
+/// child returns itself from all three methods. Wrapper chains must otherwise be acyclic and
+/// terminate in either a native [`Child`] or a self-returning non-native child.
 ///
 /// The `try_inner_child`, `try_inner_child_mut`, and `try_into_inner_child` convenience methods on
 /// the trait object traverse these layers when access to a native [`Child`] is required.

--- a/src/std/job_object.rs
+++ b/src/std/job_object.rs
@@ -1,6 +1,9 @@
 use std::{
-	io::Result,
-	os::windows::{io::AsRawHandle, process::CommandExt},
+	io::{Error, ErrorKind, Result},
+	os::windows::{
+		io::{AsRawHandle, BorrowedHandle},
+		process::CommandExt,
+	},
 	process::{Command, ExitStatus},
 	time::Duration,
 };
@@ -57,6 +60,14 @@ fn terminate_child(child: &mut dyn ChildWrapper) {
 	}
 }
 
+fn child_process_handle(child: &dyn ChildWrapper) -> Option<BorrowedHandle<'_>> {
+	child.process_handle().or_else(|| {
+		child
+			.try_inner_child()
+			.and_then(|child| child.process_handle())
+	})
+}
+
 impl CommandWrapper for JobObject {
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn pre_spawn(&mut self, command: &mut Command, core: &CommandWrap) -> Result<()> {
@@ -79,7 +90,18 @@ impl CommandWrapper for JobObject {
 			"options from other wrappers"
 		);
 
-		let handle = HANDLE(inner.inner_child().as_raw_handle() as _);
+		// Prefer the explicit capability, while preserving composition with transparent wrappers
+		// written before `process_handle` was added.
+		let handle = match child_process_handle(inner.as_ref()) {
+			Some(handle) => HANDLE(handle.as_raw_handle()),
+			None => {
+				terminate_child(&mut *inner);
+				return Err(Error::new(
+					ErrorKind::Unsupported,
+					"child wrapper does not expose a Windows process handle",
+				));
+			}
+		};
 
 		let job_port = match make_job_object(handle, false) {
 			Ok(job_port) => job_port,
@@ -122,10 +144,10 @@ impl JobObjectChild {
 
 impl ChildWrapper for JobObjectChild {
 	fn inner(&self) -> &dyn ChildWrapper {
-		self.inner.inner()
+		self.inner.as_ref()
 	}
 	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
-		self.inner.inner_mut()
+		self.inner.as_mut()
 	}
 	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
 		// manually drop the completion port
@@ -134,7 +156,10 @@ impl ChildWrapper for JobObjectChild {
 		// we leave the job handle unclosed, otherwise the Child is useless
 		// (as closing it will terminate the job)
 
-		self.inner.into_inner()
+		self.inner
+	}
+	fn process_handle(&self) -> Option<BorrowedHandle<'_>> {
+		child_process_handle(self.inner.as_ref())
 	}
 
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]

--- a/src/std/process_group.rs
+++ b/src/std/process_group.rs
@@ -151,13 +151,13 @@ impl ProcessGroupChild {
 
 impl ChildWrapper for ProcessGroupChild {
 	fn inner(&self) -> &dyn ChildWrapper {
-		self.inner.inner()
+		self.inner.as_ref()
 	}
 	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
-		self.inner.inner_mut()
+		self.inner.as_mut()
 	}
 	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
-		self.inner.into_inner()
+		self.inner
 	}
 
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]

--- a/src/tokio/core.rs
+++ b/src/tokio/core.rs
@@ -6,6 +6,9 @@ use std::{
 	process::{ExitStatus, Output},
 };
 
+#[cfg(windows)]
+use std::os::windows::io::BorrowedHandle;
+
 use futures::future::try_join3;
 #[cfg(unix)]
 use nix::{
@@ -24,9 +27,13 @@ crate::generic_wrap::Wrap!(Command, Child, ChildWrapper, |child| child);
 /// This trait exposes most of the functionality of the underlying [`Child`]. It is implemented for
 /// [`Child`] and by wrappers.
 ///
-/// The required methods are `inner`, `inner_mut`, and `into_inner`. That provides access to the
-/// underlying `Child` and allows the wrapper to be dropped and the `Child` to be used directly if
-/// necessary.
+/// The required methods are `inner`, `inner_mut`, and `into_inner`. Each non-terminal wrapper must
+/// use them to expose its direct lower layer. A terminal non-native child returns itself from all
+/// three methods. Wrapper chains must otherwise be acyclic and terminate in either a native
+/// [`Child`] or a self-returning non-native child.
+///
+/// The `try_inner_child`, `try_inner_child_mut`, and `try_into_inner_child` convenience methods on
+/// the trait object traverse these layers when access to a native [`Child`] is required.
 ///
 /// It also makes it possible for all the other methods to have default implementations. Some are
 /// direct passthroughs to the underlying `Child`, while others are more complex.
@@ -52,6 +59,13 @@ crate::generic_wrap::Wrap!(Command, Child, ChildWrapper, |child| child);
 ///     fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
 ///         Box::new((*self).0)
 ///     }
+///
+///     #[cfg(windows)]
+///     fn process_handle(
+///         &self,
+///     ) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+///         self.0.process_handle()
+///     }
 /// }
 /// ```
 pub trait ChildWrapper: Any + std::fmt::Debug + Send + Sync {
@@ -67,6 +81,20 @@ pub trait ChildWrapper: Any + std::fmt::Debug + Send + Sync {
 	/// ensure that the wrapped child is in a consistent state when this is called or they are
 	/// dropped, so that this is always safe.
 	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper>;
+
+	/// Borrow the handle for the process represented by this child, if available.
+	///
+	/// This method is only available on Windows. The returned handle cannot outlive the borrow of
+	/// `self`. Transparent child wrappers should override this method and delegate directly to the
+	/// child they own. Terminal custom children which do not represent a native process may retain the
+	/// default implementation.
+	///
+	/// Implementations returning `Some` must return a process handle, rather than another kind of
+	/// Windows object.
+	#[cfg(windows)]
+	fn process_handle(&self) -> Option<BorrowedHandle<'_>> {
+		None
+	}
 
 	/// Obtain a clone if possible.
 	///
@@ -207,7 +235,14 @@ impl ChildWrapper for Child {
 		self
 	}
 	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
-		Box::new(*self)
+		self
+	}
+	#[cfg(windows)]
+	fn process_handle(&self) -> Option<BorrowedHandle<'_>> {
+		let handle = self.raw_handle()?;
+		// SAFETY: `raw_handle` returns the handle owned by `self`, and the returned borrow cannot
+		// outlive `self`.
+		Some(unsafe { BorrowedHandle::borrow_raw(handle) })
 	}
 	fn stdin(&mut self) -> &mut Option<ChildStdin> {
 		&mut self.stdin
@@ -244,7 +279,13 @@ impl ChildWrapper for Child {
 	}
 }
 
-impl dyn ChildWrapper {
+const INNER_CHILD_INVARIANT: &str = "ChildWrapper chain did not terminate in tokio::process::Child";
+
+fn same_child(left: &dyn ChildWrapper, right: &dyn ChildWrapper) -> bool {
+	std::ptr::addr_eq(left, right) && left.type_id() == right.type_id()
+}
+
+impl dyn ChildWrapper + '_ {
 	fn downcast_ref<T: 'static>(&self) -> Option<&T> {
 		(self as &dyn Any).downcast_ref()
 	}
@@ -253,41 +294,123 @@ impl dyn ChildWrapper {
 		self.downcast_ref::<Child>().is_some()
 	}
 
-	/// Obtain a reference to the underlying [`Child`].
-	pub fn inner_child(&self) -> &Child {
+	/// Try to obtain a reference to the underlying native [`Child`].
+	///
+	/// Returns `None` if the wrapper chain terminates in a non-native child.
+	pub fn try_inner_child(&self) -> Option<&Child> {
 		let mut inner = self;
-		while !inner.is_raw_child() {
-			inner = inner.inner();
-		}
+		loop {
+			if let Some(child) = inner.downcast_ref::<Child>() {
+				return Some(child);
+			}
 
-		// UNWRAP: we've just checked that it's Some with is_raw_child()
-		inner.downcast_ref().unwrap()
+			let next = inner.inner();
+			if same_child(inner, next) {
+				return None;
+			}
+			inner = next;
+		}
 	}
 
-	/// Obtain a mutable reference to the underlying [`Child`].
+	/// Try to obtain a mutable reference to the underlying native [`Child`].
 	///
-	/// Modifying the raw child may be unsound depending on the layering of wrappers.
-	pub unsafe fn inner_child_mut(&mut self) -> &mut Child {
+	/// Returns `None` if the wrapper chain terminates in a non-native child.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that using the returned mutable child does not violate invariants
+	/// maintained by any wrapper in the chain.
+	pub unsafe fn try_inner_child_mut(&mut self) -> Option<&mut Child> {
 		let mut inner = self;
-		while !inner.is_raw_child() {
-			inner = inner.inner_mut();
-		}
+		loop {
+			if inner.is_raw_child() {
+				return (inner as &mut dyn Any).downcast_mut();
+			}
 
-		// UNWRAP: we've just checked that with is_raw_child()
-		(inner as &mut dyn Any).downcast_mut().unwrap()
+			let inner_type = (&*inner as &dyn Any).type_id();
+			let inner_ptr = std::ptr::from_mut(inner);
+			let next = inner.inner_mut();
+			if std::ptr::addr_eq(inner_ptr, std::ptr::from_mut(next))
+				&& inner_type == (&*next as &dyn Any).type_id()
+			{
+				return None;
+			}
+			inner = next;
+		}
 	}
 
-	/// Obtain the underlying [`Child`].
+	/// Try to consume the wrapper chain and obtain the underlying native [`Child`].
 	///
-	/// Unwrapping everything may be unsound depending on the state of the wrappers.
-	pub unsafe fn into_inner_child(self: Box<Self>) -> Child {
+	/// If the chain terminates in a non-native child, returns that terminal child without calling its
+	/// `into_inner` method. Wrappers already traversed before reaching it have been consumed.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that removing every traversed wrapper does not violate wrapper
+	/// invariants or bypass required cleanup. This also applies when the method returns `Err`, because
+	/// wrappers above the returned terminal child have already been consumed.
+	pub unsafe fn try_into_inner_child(self: Box<Self>) -> std::result::Result<Child, Box<Self>> {
 		let mut inner = self;
-		while !inner.is_raw_child() {
+		loop {
+			if inner.is_raw_child() {
+				return match (inner as Box<dyn Any>).downcast::<Child>() {
+					Ok(child) => Ok(*child),
+					Err(_) => unreachable!("native child type was checked before downcasting"),
+				};
+			}
+
+			let terminal = {
+				let next = inner.inner();
+				same_child(inner.as_ref(), next)
+			};
+			if terminal {
+				return Err(inner);
+			}
 			inner = inner.into_inner();
 		}
+	}
 
-		// UNWRAP: we've just checked that with is_raw_child()
-		*(inner as Box<dyn Any>).downcast().unwrap()
+	/// Obtain a reference to the underlying native [`Child`].
+	///
+	/// # Panics
+	///
+	/// Panics if the wrapper chain terminates in a non-native child.
+	#[track_caller]
+	pub fn inner_child(&self) -> &Child {
+		self.try_inner_child().expect(INNER_CHILD_INVARIANT)
+	}
+
+	/// Obtain a mutable reference to the underlying native [`Child`].
+	///
+	/// # Panics
+	///
+	/// Panics if the wrapper chain terminates in a non-native child.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that using the returned mutable child does not violate invariants
+	/// maintained by any wrapper in the chain.
+	#[track_caller]
+	pub unsafe fn inner_child_mut(&mut self) -> &mut Child {
+		unsafe { self.try_inner_child_mut() }.expect(INNER_CHILD_INVARIANT)
+	}
+
+	/// Consume the wrapper chain and obtain the underlying native [`Child`].
+	///
+	/// # Panics
+	///
+	/// Panics if the wrapper chain terminates in a non-native child.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that removing every traversed wrapper does not violate wrapper
+	/// invariants or bypass required cleanup.
+	#[track_caller]
+	pub unsafe fn into_inner_child(self: Box<Self>) -> Child {
+		match unsafe { self.try_into_inner_child() } {
+			Ok(child) => child,
+			Err(_) => panic!("{INNER_CHILD_INVARIANT}"),
+		}
 	}
 }
 

--- a/src/tokio/core.rs
+++ b/src/tokio/core.rs
@@ -282,8 +282,6 @@ impl ChildWrapper for Child {
 	}
 }
 
-const INNER_CHILD_INVARIANT: &str = "ChildWrapper chain did not terminate in tokio::process::Child";
-
 fn same_child(left: &dyn ChildWrapper, right: &dyn ChildWrapper) -> bool {
 	std::ptr::addr_eq(left, right) && left.type_id() == right.type_id()
 }
@@ -370,49 +368,6 @@ impl dyn ChildWrapper + '_ {
 				return Err(inner);
 			}
 			inner = inner.into_inner();
-		}
-	}
-
-	/// Obtain a reference to the underlying native [`Child`].
-	///
-	/// # Panics
-	///
-	/// Panics if the wrapper chain terminates in a non-native child.
-	#[track_caller]
-	pub fn inner_child(&self) -> &Child {
-		self.try_inner_child().expect(INNER_CHILD_INVARIANT)
-	}
-
-	/// Obtain a mutable reference to the underlying native [`Child`].
-	///
-	/// # Panics
-	///
-	/// Panics if the wrapper chain terminates in a non-native child.
-	///
-	/// # Safety
-	///
-	/// The caller must ensure that using the returned mutable child does not violate invariants
-	/// maintained by any wrapper in the chain.
-	#[track_caller]
-	pub unsafe fn inner_child_mut(&mut self) -> &mut Child {
-		unsafe { self.try_inner_child_mut() }.expect(INNER_CHILD_INVARIANT)
-	}
-
-	/// Consume the wrapper chain and obtain the underlying native [`Child`].
-	///
-	/// # Panics
-	///
-	/// Panics if the wrapper chain terminates in a non-native child.
-	///
-	/// # Safety
-	///
-	/// The caller must ensure that removing every traversed wrapper does not violate wrapper
-	/// invariants or bypass required cleanup.
-	#[track_caller]
-	pub unsafe fn into_inner_child(self: Box<Self>) -> Child {
-		match unsafe { self.try_into_inner_child() } {
-			Ok(child) => child,
-			Err(_) => panic!("{INNER_CHILD_INVARIANT}"),
 		}
 	}
 }

--- a/src/tokio/core.rs
+++ b/src/tokio/core.rs
@@ -27,10 +27,13 @@ crate::generic_wrap::Wrap!(Command, Child, ChildWrapper, |child| child);
 /// This trait exposes most of the functionality of the underlying [`Child`]. It is implemented for
 /// [`Child`] and by wrappers.
 ///
-/// The required methods are `inner`, `inner_mut`, and `into_inner`. Each non-terminal wrapper must
-/// use them to expose its direct lower layer. A terminal non-native child returns itself from all
-/// three methods. Wrapper chains must otherwise be acyclic and terminate in either a native
-/// [`Child`] or a self-returning non-native child.
+/// The required methods are `inner`, `inner_mut`, and `into_inner`. Together they expose each lower
+/// layer, allowing wrappers to be unwrapped and the native [`Child`] to be used directly when
+/// necessary.
+///
+/// Each non-terminal wrapper must use them to expose its direct lower layer. A terminal non-native
+/// child returns itself from all three methods. Wrapper chains must otherwise be acyclic and
+/// terminate in either a native [`Child`] or a self-returning non-native child.
 ///
 /// The `try_inner_child`, `try_inner_child_mut`, and `try_into_inner_child` convenience methods on
 /// the trait object traverse these layers when access to a native [`Child`] is required.

--- a/src/tokio/job_object.rs
+++ b/src/tokio/job_object.rs
@@ -1,4 +1,11 @@
-use std::{future::Future, io::Result, pin::Pin, process::ExitStatus, time::Duration};
+use std::{
+	future::Future,
+	io::{Error, ErrorKind, Result},
+	os::windows::io::{AsRawHandle, BorrowedHandle},
+	pin::Pin,
+	process::ExitStatus,
+	time::Duration,
+};
 
 use tokio::{process::Command, task::spawn_blocking};
 #[cfg(feature = "tracing")]
@@ -53,6 +60,14 @@ fn terminate_child(child: &mut dyn ChildWrapper) {
 	let _ = child.start_kill();
 }
 
+fn child_process_handle(child: &dyn ChildWrapper) -> Option<BorrowedHandle<'_>> {
+	child.process_handle().or_else(|| {
+		child
+			.try_inner_child()
+			.and_then(|child| child.process_handle())
+	})
+}
+
 impl CommandWrapper for JobObject {
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn pre_spawn(&mut self, command: &mut Command, core: &CommandWrap) -> Result<()> {
@@ -81,12 +96,18 @@ impl CommandWrapper for JobObject {
 			"options from other wrappers"
 		);
 
-		let handle = HANDLE(
-			inner
-				.inner_child()
-				.raw_handle()
-				.expect("child has exited but it has not even started") as _,
-		);
+		// Prefer the explicit capability, while preserving composition with transparent wrappers
+		// written before `process_handle` was added.
+		let handle = match child_process_handle(inner.as_ref()) {
+			Some(handle) => HANDLE(handle.as_raw_handle()),
+			None => {
+				terminate_child(&mut *inner);
+				return Err(Error::new(
+					ErrorKind::Unsupported,
+					"child wrapper does not expose a Windows process handle",
+				));
+			}
+		};
 
 		let job_port = match make_job_object(handle, kill_on_drop) {
 			Ok(job_port) => job_port,
@@ -129,10 +150,10 @@ impl JobObjectChild {
 
 impl ChildWrapper for JobObjectChild {
 	fn inner(&self) -> &dyn ChildWrapper {
-		self.inner.inner()
+		self.inner.as_ref()
 	}
 	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
-		self.inner.inner_mut()
+		self.inner.as_mut()
 	}
 	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
 		// manually drop the completion port
@@ -141,7 +162,10 @@ impl ChildWrapper for JobObjectChild {
 		// we leave the job handle unclosed, otherwise the Child is useless
 		// (as closing it will terminate the job)
 
-		self.inner.into_inner()
+		self.inner
+	}
+	fn process_handle(&self) -> Option<BorrowedHandle<'_>> {
+		child_process_handle(self.inner.as_ref())
 	}
 
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]

--- a/src/tokio/process_group.rs
+++ b/src/tokio/process_group.rs
@@ -161,13 +161,13 @@ impl ProcessGroupChild {
 
 impl ChildWrapper for ProcessGroupChild {
 	fn inner(&self) -> &dyn ChildWrapper {
-		self.inner.inner()
+		self.inner.as_ref()
 	}
 	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
-		self.inner.inner_mut()
+		self.inner.as_mut()
 	}
 	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
-		self.inner.into_inner()
+		self.inner
 	}
 
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]

--- a/tests/child_wrapper_contract.rs
+++ b/tests/child_wrapper_contract.rs
@@ -4,7 +4,6 @@
 mod std_frontend {
 	use std::{
 		any::TypeId,
-		panic::{AssertUnwindSafe, catch_unwind},
 		process::{Child, Command},
 		sync::{
 			Arc,
@@ -273,16 +272,6 @@ mod std_frontend {
 		child.type_id() == TypeId::of::<T>()
 	}
 
-	fn panic_text(payload: Box<dyn std::any::Any + Send>) -> String {
-		if let Some(message) = payload.downcast_ref::<&str>() {
-			(*message).to_owned()
-		} else if let Some(message) = payload.downcast_ref::<String>() {
-			message.clone()
-		} else {
-			"non-string panic".to_owned()
-		}
-	}
-
 	#[test]
 	fn native_child_try_accessors_traverse_layers() {
 		let mut child = layered_native();
@@ -319,16 +308,6 @@ mod std_frontend {
 		let mut child = unsafe { child.try_into_inner_child() }.expect("native child");
 		child.wait().expect("reap consuming-test child");
 		assert_eq!(into_inner_calls.load(Ordering::SeqCst), 2);
-	}
-
-	#[test]
-	fn legacy_native_accessors_still_traverse_layers() {
-		let mut child = layered_native();
-		let id = child.inner_child().id();
-		assert_eq!(unsafe { child.inner_child_mut() }.id(), id);
-		let mut child = unsafe { child.into_inner_child() };
-		assert_eq!(child.id(), id);
-		child.wait().expect("reap legacy-accessor child");
 	}
 
 	#[test]
@@ -372,26 +351,6 @@ mod std_frontend {
 		assert_eq!(calls.into_inner.load(Ordering::SeqCst), 0);
 		drop(child);
 		assert_eq!(calls.drops.load(Ordering::SeqCst), 1);
-	}
-
-	#[test]
-	fn legacy_accessors_panic_for_non_native_leaves() {
-		let (child, _) = leaf();
-		let panic = catch_unwind(AssertUnwindSafe(|| child.inner_child()))
-			.expect_err("immutable accessor must panic");
-		assert!(panic_text(panic).contains("std::process::Child"));
-
-		let (mut child, _) = leaf();
-		let panic = catch_unwind(AssertUnwindSafe(|| unsafe {
-			let _ = child.inner_child_mut();
-		}))
-		.expect_err("mutable accessor must panic");
-		assert!(panic_text(panic).contains("std::process::Child"));
-
-		let (child, _) = leaf();
-		let panic = catch_unwind(AssertUnwindSafe(|| unsafe { child.into_inner_child() }))
-			.expect_err("consuming accessor must panic");
-		assert!(panic_text(panic).contains("std::process::Child"));
 	}
 
 	#[test]
@@ -443,7 +402,6 @@ mod std_frontend {
 mod tokio_frontend {
 	use std::{
 		any::TypeId,
-		panic::{AssertUnwindSafe, catch_unwind},
 		sync::{
 			Arc,
 			atomic::{AtomicUsize, Ordering},
@@ -712,16 +670,6 @@ mod tokio_frontend {
 		child.type_id() == TypeId::of::<T>()
 	}
 
-	fn panic_text(payload: Box<dyn std::any::Any + Send>) -> String {
-		if let Some(message) = payload.downcast_ref::<&str>() {
-			(*message).to_owned()
-		} else if let Some(message) = payload.downcast_ref::<String>() {
-			message.clone()
-		} else {
-			"non-string panic".to_owned()
-		}
-	}
-
 	#[tokio::test]
 	async fn native_child_try_accessors_traverse_layers() {
 		let mut child = layered_native();
@@ -758,16 +706,6 @@ mod tokio_frontend {
 		let mut child = unsafe { child.try_into_inner_child() }.expect("native child");
 		child.wait().await.expect("reap consuming-test child");
 		assert_eq!(into_inner_calls.load(Ordering::SeqCst), 2);
-	}
-
-	#[tokio::test]
-	async fn legacy_native_accessors_still_traverse_layers() {
-		let mut child = layered_native();
-		let id = child.inner_child().id();
-		assert_eq!(unsafe { child.inner_child_mut() }.id(), id);
-		let mut child = unsafe { child.into_inner_child() };
-		assert_eq!(child.id(), id);
-		child.wait().await.expect("reap legacy-accessor child");
 	}
 
 	#[tokio::test]
@@ -811,26 +749,6 @@ mod tokio_frontend {
 		assert_eq!(calls.into_inner.load(Ordering::SeqCst), 0);
 		drop(child);
 		assert_eq!(calls.drops.load(Ordering::SeqCst), 1);
-	}
-
-	#[tokio::test]
-	async fn legacy_accessors_panic_for_non_native_leaves() {
-		let (child, _) = leaf();
-		let panic = catch_unwind(AssertUnwindSafe(|| child.inner_child()))
-			.expect_err("immutable accessor must panic");
-		assert!(panic_text(panic).contains("tokio::process::Child"));
-
-		let (mut child, _) = leaf();
-		let panic = catch_unwind(AssertUnwindSafe(|| unsafe {
-			let _ = child.inner_child_mut();
-		}))
-		.expect_err("mutable accessor must panic");
-		assert!(panic_text(panic).contains("tokio::process::Child"));
-
-		let (child, _) = leaf();
-		let panic = catch_unwind(AssertUnwindSafe(|| unsafe { child.into_inner_child() }))
-			.expect_err("consuming accessor must panic");
-		assert!(panic_text(panic).contains("tokio::process::Child"));
 	}
 
 	#[tokio::test]

--- a/tests/child_wrapper_contract.rs
+++ b/tests/child_wrapper_contract.rs
@@ -1,0 +1,891 @@
+#![cfg(all(any(feature = "std", feature = "tokio1"), any(unix, windows)))]
+
+#[cfg(feature = "std")]
+mod std_frontend {
+	use std::{
+		any::TypeId,
+		panic::{AssertUnwindSafe, catch_unwind},
+		process::{Child, Command},
+		sync::{
+			Arc,
+			atomic::{AtomicUsize, Ordering},
+		},
+	};
+
+	use process_wrap::std::ChildWrapper;
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	use process_wrap::std::{CommandWrap, CommandWrapper};
+
+	#[derive(Debug)]
+	struct Layer {
+		inner: Option<Box<dyn ChildWrapper>>,
+		drops: Arc<AtomicUsize>,
+	}
+
+	impl Layer {
+		fn new(inner: Box<dyn ChildWrapper>) -> Self {
+			Self::tracked(inner, Arc::new(AtomicUsize::new(0)))
+		}
+
+		fn tracked(inner: Box<dyn ChildWrapper>, drops: Arc<AtomicUsize>) -> Self {
+			Self {
+				inner: Some(inner),
+				drops,
+			}
+		}
+
+		fn child(&self) -> &dyn ChildWrapper {
+			self.inner
+				.as_deref()
+				.expect("the layer still owns its child")
+		}
+
+		fn child_mut(&mut self) -> &mut dyn ChildWrapper {
+			self.inner
+				.as_deref_mut()
+				.expect("the layer still owns its child")
+		}
+	}
+
+	impl Drop for Layer {
+		fn drop(&mut self) {
+			self.drops.fetch_add(1, Ordering::SeqCst);
+		}
+	}
+
+	impl ChildWrapper for Layer {
+		fn inner(&self) -> &dyn ChildWrapper {
+			self.child()
+		}
+
+		fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+			self.child_mut()
+		}
+
+		fn into_inner(mut self: Box<Self>) -> Box<dyn ChildWrapper> {
+			self.inner.take().expect("the layer still owns its child")
+		}
+
+		#[cfg(windows)]
+		fn process_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+			self.child().process_handle()
+		}
+	}
+
+	#[derive(Debug, Default)]
+	struct LeafCalls {
+		inner: AtomicUsize,
+		inner_mut: AtomicUsize,
+		into_inner: AtomicUsize,
+		drops: AtomicUsize,
+	}
+
+	#[derive(Debug)]
+	struct Leaf(Arc<LeafCalls>);
+
+	impl Drop for Leaf {
+		fn drop(&mut self) {
+			self.0.drops.fetch_add(1, Ordering::SeqCst);
+		}
+	}
+
+	impl ChildWrapper for Leaf {
+		fn inner(&self) -> &dyn ChildWrapper {
+			self.0.inner.fetch_add(1, Ordering::SeqCst);
+			self
+		}
+
+		fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+			self.0.inner_mut.fetch_add(1, Ordering::SeqCst);
+			self
+		}
+
+		fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+			self.0.into_inner.fetch_add(1, Ordering::SeqCst);
+			self
+		}
+	}
+
+	#[repr(transparent)]
+	#[derive(Debug)]
+	struct InlineLayer(Child);
+
+	impl ChildWrapper for InlineLayer {
+		fn inner(&self) -> &dyn ChildWrapper {
+			&self.0
+		}
+
+		fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+			&mut self.0
+		}
+
+		fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+			Box::new(self.0)
+		}
+
+		#[cfg(windows)]
+		fn process_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+			self.0.process_handle()
+		}
+	}
+
+	#[derive(Debug)]
+	enum ReusedChild {
+		Layer(Box<ReusingLayer>),
+		Native(Box<Child>),
+		Taken,
+	}
+
+	#[derive(Debug)]
+	struct ReusingLayer {
+		inner: ReusedChild,
+		into_inner_calls: Arc<AtomicUsize>,
+	}
+
+	impl ChildWrapper for ReusingLayer {
+		fn inner(&self) -> &dyn ChildWrapper {
+			match &self.inner {
+				ReusedChild::Layer(child) => child.as_ref(),
+				ReusedChild::Native(child) => child.as_ref(),
+				ReusedChild::Taken => unreachable!("the layer still owns its child"),
+			}
+		}
+
+		fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+			match &mut self.inner {
+				ReusedChild::Layer(child) => child.as_mut(),
+				ReusedChild::Native(child) => child.as_mut(),
+				ReusedChild::Taken => unreachable!("the layer still owns its child"),
+			}
+		}
+
+		fn into_inner(mut self: Box<Self>) -> Box<dyn ChildWrapper> {
+			self.into_inner_calls.fetch_add(1, Ordering::SeqCst);
+			match std::mem::replace(&mut self.inner, ReusedChild::Taken) {
+				ReusedChild::Layer(child) => {
+					*self = *child;
+					self
+				}
+				ReusedChild::Native(child) => child,
+				ReusedChild::Taken => unreachable!("the layer still owns its child"),
+			}
+		}
+
+		#[cfg(windows)]
+		fn process_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+			self.inner().process_handle()
+		}
+	}
+
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	#[derive(Debug)]
+	struct MarkerCommand;
+
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	#[derive(Debug)]
+	struct MarkerChild(Box<dyn ChildWrapper>);
+
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	impl CommandWrapper for MarkerCommand {
+		fn wrap_child(
+			&mut self,
+			child: Box<dyn ChildWrapper>,
+			_core: &CommandWrap,
+		) -> std::io::Result<Box<dyn ChildWrapper>> {
+			Ok(Box::new(MarkerChild(child)))
+		}
+	}
+
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	impl ChildWrapper for MarkerChild {
+		fn inner(&self) -> &dyn ChildWrapper {
+			self.0.as_ref()
+		}
+
+		fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+			self.0.as_mut()
+		}
+
+		fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+			self.0
+		}
+
+		#[cfg(windows)]
+		fn process_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+			self.0.process_handle()
+		}
+	}
+
+	fn native_child() -> Child {
+		#[cfg(unix)]
+		return Command::new("sh")
+			.args(["-c", "exit 0"])
+			.spawn()
+			.expect("spawn native child");
+
+		#[cfg(windows)]
+		return Command::new("cmd.exe")
+			.args(["/D", "/S", "/C", "exit /b 0"])
+			.spawn()
+			.expect("spawn native child");
+	}
+
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	fn wrapped_command() -> CommandWrap {
+		#[cfg(unix)]
+		return CommandWrap::with_new("sh", |command| {
+			command.args(["-c", "exit 0"]);
+		});
+
+		#[cfg(windows)]
+		return CommandWrap::with_new("cmd.exe", |command| {
+			command.args(["/D", "/S", "/C", "exit /b 0"]);
+		});
+	}
+
+	fn layered_native() -> Box<dyn ChildWrapper> {
+		Box::new(Layer::new(Box::new(Layer::new(Box::new(native_child())))))
+	}
+
+	fn reusing_native() -> (Box<dyn ChildWrapper>, Arc<AtomicUsize>) {
+		let calls = Arc::new(AtomicUsize::new(0));
+		let inner = ReusingLayer {
+			inner: ReusedChild::Native(Box::new(native_child())),
+			into_inner_calls: Arc::clone(&calls),
+		};
+		let outer = ReusingLayer {
+			inner: ReusedChild::Layer(Box::new(inner)),
+			into_inner_calls: Arc::clone(&calls),
+		};
+		(Box::new(outer), calls)
+	}
+
+	fn leaf() -> (Box<dyn ChildWrapper>, Arc<LeafCalls>) {
+		let calls = Arc::new(LeafCalls::default());
+		(Box::new(Leaf(Arc::clone(&calls))), calls)
+	}
+
+	fn data_ptr(child: &dyn ChildWrapper) -> *const () {
+		child as *const dyn ChildWrapper as *const ()
+	}
+
+	fn is_type<T: 'static>(child: &dyn ChildWrapper) -> bool {
+		child.type_id() == TypeId::of::<T>()
+	}
+
+	fn panic_text(payload: Box<dyn std::any::Any + Send>) -> String {
+		if let Some(message) = payload.downcast_ref::<&str>() {
+			(*message).to_owned()
+		} else if let Some(message) = payload.downcast_ref::<String>() {
+			message.clone()
+		} else {
+			"non-string panic".to_owned()
+		}
+	}
+
+	#[test]
+	fn native_child_try_accessors_traverse_layers() {
+		let mut child = layered_native();
+		assert!(child.try_inner_child().is_some());
+		child.wait().expect("reap immutable-test child");
+
+		let mut child = layered_native();
+		assert!(unsafe { child.try_inner_child_mut() }.is_some());
+		child.wait().expect("reap mutable-test child");
+
+		let child = layered_native();
+		let mut child = unsafe { child.try_into_inner_child() }.expect("native child");
+		child.wait().expect("reap consuming-test child");
+	}
+
+	#[test]
+	fn inline_native_child_is_not_mistaken_for_a_self_leaf() {
+		let mut child: Box<dyn ChildWrapper> = Box::new(InlineLayer(native_child()));
+		assert!(child.try_inner_child().is_some());
+		child.wait().expect("reap immutable-test child");
+
+		let mut child: Box<dyn ChildWrapper> = Box::new(InlineLayer(native_child()));
+		assert!(unsafe { child.try_inner_child_mut() }.is_some());
+		child.wait().expect("reap mutable-test child");
+
+		let child: Box<dyn ChildWrapper> = Box::new(InlineLayer(native_child()));
+		let mut child = unsafe { child.try_into_inner_child() }.expect("native child");
+		child.wait().expect("reap consuming-test child");
+	}
+
+	#[test]
+	fn consuming_traversal_allows_same_type_to_reuse_its_allocation() {
+		let (child, into_inner_calls) = reusing_native();
+		let mut child = unsafe { child.try_into_inner_child() }.expect("native child");
+		child.wait().expect("reap consuming-test child");
+		assert_eq!(into_inner_calls.load(Ordering::SeqCst), 2);
+	}
+
+	#[test]
+	fn legacy_native_accessors_still_traverse_layers() {
+		let mut child = layered_native();
+		let id = child.inner_child().id();
+		assert_eq!(unsafe { child.inner_child_mut() }.id(), id);
+		let mut child = unsafe { child.into_inner_child() };
+		assert_eq!(child.id(), id);
+		child.wait().expect("reap legacy-accessor child");
+	}
+
+	#[test]
+	fn self_leaf_try_accessors_preserve_ownership() {
+		let (mut child, calls) = leaf();
+		assert!(child.try_inner_child().is_none());
+		assert!(unsafe { child.try_inner_child_mut() }.is_none());
+
+		let original = data_ptr(child.as_ref());
+		let child = unsafe { child.try_into_inner_child() }
+			.expect_err("a non-native leaf must be returned");
+		assert_eq!(data_ptr(child.as_ref()), original);
+		assert!(is_type::<Leaf>(child.as_ref()));
+		assert_eq!(calls.inner.load(Ordering::SeqCst), 2);
+		assert_eq!(calls.inner_mut.load(Ordering::SeqCst), 1);
+		assert_eq!(calls.into_inner.load(Ordering::SeqCst), 0);
+		assert_eq!(calls.drops.load(Ordering::SeqCst), 0);
+		drop(child);
+		assert_eq!(calls.drops.load(Ordering::SeqCst), 1);
+	}
+
+	#[test]
+	fn nested_non_native_leaf_is_returned_after_layers_are_consumed() {
+		let (leaf, calls) = leaf();
+		let leaf_ptr = data_ptr(leaf.as_ref());
+		let layer_drops = Arc::new(AtomicUsize::new(0));
+		let mut child: Box<dyn ChildWrapper> = Box::new(Layer::tracked(
+			Box::new(Layer::tracked(leaf, Arc::clone(&layer_drops))),
+			Arc::clone(&layer_drops),
+		));
+
+		assert!(child.try_inner_child().is_none());
+		assert!(unsafe { child.try_inner_child_mut() }.is_none());
+		let child = unsafe { child.try_into_inner_child() }
+			.expect_err("the terminal leaf must be returned");
+		assert_eq!(data_ptr(child.as_ref()), leaf_ptr);
+		assert!(is_type::<Leaf>(child.as_ref()));
+		assert_eq!(layer_drops.load(Ordering::SeqCst), 2);
+		assert_eq!(calls.inner.load(Ordering::SeqCst), 2);
+		assert_eq!(calls.inner_mut.load(Ordering::SeqCst), 1);
+		assert_eq!(calls.into_inner.load(Ordering::SeqCst), 0);
+		drop(child);
+		assert_eq!(calls.drops.load(Ordering::SeqCst), 1);
+	}
+
+	#[test]
+	fn legacy_accessors_panic_for_non_native_leaves() {
+		let (child, _) = leaf();
+		let panic = catch_unwind(AssertUnwindSafe(|| child.inner_child()))
+			.expect_err("immutable accessor must panic");
+		assert!(panic_text(panic).contains("std::process::Child"));
+
+		let (mut child, _) = leaf();
+		let panic = catch_unwind(AssertUnwindSafe(|| unsafe {
+			let _ = child.inner_child_mut();
+		}))
+		.expect_err("mutable accessor must panic");
+		assert!(panic_text(panic).contains("std::process::Child"));
+
+		let (child, _) = leaf();
+		let panic = catch_unwind(AssertUnwindSafe(|| unsafe { child.into_inner_child() }))
+			.expect_err("consuming accessor must panic");
+		assert!(panic_text(panic).contains("std::process::Child"));
+	}
+
+	#[test]
+	fn lifecycle_is_repeatable_through_custom_layers() {
+		let mut child = layered_native();
+		let first = child.wait().expect("first wait");
+		let second = child.wait().expect("second wait");
+		let third = child
+			.try_wait()
+			.expect("try_wait")
+			.expect("child has exited");
+		assert!(first.success());
+		assert_eq!(first, second);
+		assert_eq!(first, third);
+	}
+
+	#[cfg(all(unix, feature = "process-group"))]
+	#[test]
+	fn process_group_exposes_its_immediate_custom_child() {
+		use process_wrap::std::ProcessGroup;
+
+		let mut command = wrapped_command();
+		command.wrap(MarkerCommand).wrap(ProcessGroup::leader());
+		let mut child = command.spawn().expect("spawn process group");
+		assert!(is_type::<MarkerChild>(child.inner()));
+		assert!(is_type::<MarkerChild>(child.inner_mut()));
+		let mut child = child.into_inner();
+		assert!(is_type::<MarkerChild>(child.as_ref()));
+		assert!(child.wait().expect("reap process-group child").success());
+	}
+
+	#[cfg(all(unix, feature = "process-session"))]
+	#[test]
+	fn process_session_exposes_its_immediate_custom_child() {
+		use process_wrap::std::ProcessSession;
+
+		let mut command = wrapped_command();
+		command.wrap(MarkerCommand).wrap(ProcessSession);
+		let mut child = command.spawn().expect("spawn process session");
+		assert!(is_type::<MarkerChild>(child.inner()));
+		assert!(is_type::<MarkerChild>(child.inner_mut()));
+		let mut child = child.into_inner();
+		assert!(is_type::<MarkerChild>(child.as_ref()));
+		assert!(child.wait().expect("reap process-session child").success());
+	}
+}
+
+#[cfg(feature = "tokio1")]
+mod tokio_frontend {
+	use std::{
+		any::TypeId,
+		panic::{AssertUnwindSafe, catch_unwind},
+		sync::{
+			Arc,
+			atomic::{AtomicUsize, Ordering},
+		},
+	};
+
+	use process_wrap::tokio::ChildWrapper;
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	use process_wrap::tokio::{CommandWrap, CommandWrapper};
+	use tokio::process::{Child, Command};
+
+	#[derive(Debug)]
+	struct Layer {
+		inner: Option<Box<dyn ChildWrapper>>,
+		drops: Arc<AtomicUsize>,
+	}
+
+	impl Layer {
+		fn new(inner: Box<dyn ChildWrapper>) -> Self {
+			Self::tracked(inner, Arc::new(AtomicUsize::new(0)))
+		}
+
+		fn tracked(inner: Box<dyn ChildWrapper>, drops: Arc<AtomicUsize>) -> Self {
+			Self {
+				inner: Some(inner),
+				drops,
+			}
+		}
+
+		fn child(&self) -> &dyn ChildWrapper {
+			self.inner
+				.as_deref()
+				.expect("the layer still owns its child")
+		}
+
+		fn child_mut(&mut self) -> &mut dyn ChildWrapper {
+			self.inner
+				.as_deref_mut()
+				.expect("the layer still owns its child")
+		}
+	}
+
+	impl Drop for Layer {
+		fn drop(&mut self) {
+			self.drops.fetch_add(1, Ordering::SeqCst);
+		}
+	}
+
+	impl ChildWrapper for Layer {
+		fn inner(&self) -> &dyn ChildWrapper {
+			self.child()
+		}
+
+		fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+			self.child_mut()
+		}
+
+		fn into_inner(mut self: Box<Self>) -> Box<dyn ChildWrapper> {
+			self.inner.take().expect("the layer still owns its child")
+		}
+
+		#[cfg(windows)]
+		fn process_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+			self.child().process_handle()
+		}
+	}
+
+	#[derive(Debug, Default)]
+	struct LeafCalls {
+		inner: AtomicUsize,
+		inner_mut: AtomicUsize,
+		into_inner: AtomicUsize,
+		drops: AtomicUsize,
+	}
+
+	#[derive(Debug)]
+	struct Leaf(Arc<LeafCalls>);
+
+	impl Drop for Leaf {
+		fn drop(&mut self) {
+			self.0.drops.fetch_add(1, Ordering::SeqCst);
+		}
+	}
+
+	impl ChildWrapper for Leaf {
+		fn inner(&self) -> &dyn ChildWrapper {
+			self.0.inner.fetch_add(1, Ordering::SeqCst);
+			self
+		}
+
+		fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+			self.0.inner_mut.fetch_add(1, Ordering::SeqCst);
+			self
+		}
+
+		fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+			self.0.into_inner.fetch_add(1, Ordering::SeqCst);
+			self
+		}
+	}
+
+	#[repr(transparent)]
+	#[derive(Debug)]
+	struct InlineLayer(Child);
+
+	impl ChildWrapper for InlineLayer {
+		fn inner(&self) -> &dyn ChildWrapper {
+			&self.0
+		}
+
+		fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+			&mut self.0
+		}
+
+		fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+			Box::new(self.0)
+		}
+
+		#[cfg(windows)]
+		fn process_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+			self.0.process_handle()
+		}
+	}
+
+	#[derive(Debug)]
+	enum ReusedChild {
+		Layer(Box<ReusingLayer>),
+		Native(Box<Child>),
+		Taken,
+	}
+
+	#[derive(Debug)]
+	struct ReusingLayer {
+		inner: ReusedChild,
+		into_inner_calls: Arc<AtomicUsize>,
+	}
+
+	impl ChildWrapper for ReusingLayer {
+		fn inner(&self) -> &dyn ChildWrapper {
+			match &self.inner {
+				ReusedChild::Layer(child) => child.as_ref(),
+				ReusedChild::Native(child) => child.as_ref(),
+				ReusedChild::Taken => unreachable!("the layer still owns its child"),
+			}
+		}
+
+		fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+			match &mut self.inner {
+				ReusedChild::Layer(child) => child.as_mut(),
+				ReusedChild::Native(child) => child.as_mut(),
+				ReusedChild::Taken => unreachable!("the layer still owns its child"),
+			}
+		}
+
+		fn into_inner(mut self: Box<Self>) -> Box<dyn ChildWrapper> {
+			self.into_inner_calls.fetch_add(1, Ordering::SeqCst);
+			match std::mem::replace(&mut self.inner, ReusedChild::Taken) {
+				ReusedChild::Layer(child) => {
+					*self = *child;
+					self
+				}
+				ReusedChild::Native(child) => child,
+				ReusedChild::Taken => unreachable!("the layer still owns its child"),
+			}
+		}
+
+		#[cfg(windows)]
+		fn process_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+			self.inner().process_handle()
+		}
+	}
+
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	#[derive(Debug)]
+	struct MarkerCommand;
+
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	#[derive(Debug)]
+	struct MarkerChild(Box<dyn ChildWrapper>);
+
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	impl CommandWrapper for MarkerCommand {
+		fn wrap_child(
+			&mut self,
+			child: Box<dyn ChildWrapper>,
+			_core: &CommandWrap,
+		) -> std::io::Result<Box<dyn ChildWrapper>> {
+			Ok(Box::new(MarkerChild(child)))
+		}
+	}
+
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	impl ChildWrapper for MarkerChild {
+		fn inner(&self) -> &dyn ChildWrapper {
+			self.0.as_ref()
+		}
+
+		fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+			self.0.as_mut()
+		}
+
+		fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+			self.0
+		}
+
+		#[cfg(windows)]
+		fn process_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+			self.0.process_handle()
+		}
+	}
+
+	fn native_child() -> Child {
+		#[cfg(unix)]
+		return Command::new("sh")
+			.args(["-c", "exit 0"])
+			.spawn()
+			.expect("spawn native child");
+
+		#[cfg(windows)]
+		return Command::new("cmd.exe")
+			.args(["/D", "/S", "/C", "exit /b 0"])
+			.spawn()
+			.expect("spawn native child");
+	}
+
+	#[cfg(all(unix, any(feature = "process-group", feature = "process-session")))]
+	fn wrapped_command() -> CommandWrap {
+		#[cfg(unix)]
+		return CommandWrap::with_new("sh", |command| {
+			command.args(["-c", "exit 0"]);
+		});
+
+		#[cfg(windows)]
+		return CommandWrap::with_new("cmd.exe", |command| {
+			command.args(["/D", "/S", "/C", "exit /b 0"]);
+		});
+	}
+
+	fn layered_native() -> Box<dyn ChildWrapper> {
+		Box::new(Layer::new(Box::new(Layer::new(Box::new(native_child())))))
+	}
+
+	fn reusing_native() -> (Box<dyn ChildWrapper>, Arc<AtomicUsize>) {
+		let calls = Arc::new(AtomicUsize::new(0));
+		let inner = ReusingLayer {
+			inner: ReusedChild::Native(Box::new(native_child())),
+			into_inner_calls: Arc::clone(&calls),
+		};
+		let outer = ReusingLayer {
+			inner: ReusedChild::Layer(Box::new(inner)),
+			into_inner_calls: Arc::clone(&calls),
+		};
+		(Box::new(outer), calls)
+	}
+
+	fn leaf() -> (Box<dyn ChildWrapper>, Arc<LeafCalls>) {
+		let calls = Arc::new(LeafCalls::default());
+		(Box::new(Leaf(Arc::clone(&calls))), calls)
+	}
+
+	fn data_ptr(child: &dyn ChildWrapper) -> *const () {
+		child as *const dyn ChildWrapper as *const ()
+	}
+
+	fn is_type<T: 'static>(child: &dyn ChildWrapper) -> bool {
+		child.type_id() == TypeId::of::<T>()
+	}
+
+	fn panic_text(payload: Box<dyn std::any::Any + Send>) -> String {
+		if let Some(message) = payload.downcast_ref::<&str>() {
+			(*message).to_owned()
+		} else if let Some(message) = payload.downcast_ref::<String>() {
+			message.clone()
+		} else {
+			"non-string panic".to_owned()
+		}
+	}
+
+	#[tokio::test]
+	async fn native_child_try_accessors_traverse_layers() {
+		let mut child = layered_native();
+		assert!(child.try_inner_child().is_some());
+		child.wait().await.expect("reap immutable-test child");
+
+		let mut child = layered_native();
+		assert!(unsafe { child.try_inner_child_mut() }.is_some());
+		child.wait().await.expect("reap mutable-test child");
+
+		let child = layered_native();
+		let mut child = unsafe { child.try_into_inner_child() }.expect("native child");
+		child.wait().await.expect("reap consuming-test child");
+	}
+
+	#[tokio::test]
+	async fn inline_native_child_is_not_mistaken_for_a_self_leaf() {
+		let mut child: Box<dyn ChildWrapper> = Box::new(InlineLayer(native_child()));
+		assert!(child.try_inner_child().is_some());
+		child.wait().await.expect("reap immutable-test child");
+
+		let mut child: Box<dyn ChildWrapper> = Box::new(InlineLayer(native_child()));
+		assert!(unsafe { child.try_inner_child_mut() }.is_some());
+		child.wait().await.expect("reap mutable-test child");
+
+		let child: Box<dyn ChildWrapper> = Box::new(InlineLayer(native_child()));
+		let mut child = unsafe { child.try_into_inner_child() }.expect("native child");
+		child.wait().await.expect("reap consuming-test child");
+	}
+
+	#[tokio::test]
+	async fn consuming_traversal_allows_same_type_to_reuse_its_allocation() {
+		let (child, into_inner_calls) = reusing_native();
+		let mut child = unsafe { child.try_into_inner_child() }.expect("native child");
+		child.wait().await.expect("reap consuming-test child");
+		assert_eq!(into_inner_calls.load(Ordering::SeqCst), 2);
+	}
+
+	#[tokio::test]
+	async fn legacy_native_accessors_still_traverse_layers() {
+		let mut child = layered_native();
+		let id = child.inner_child().id();
+		assert_eq!(unsafe { child.inner_child_mut() }.id(), id);
+		let mut child = unsafe { child.into_inner_child() };
+		assert_eq!(child.id(), id);
+		child.wait().await.expect("reap legacy-accessor child");
+	}
+
+	#[tokio::test]
+	async fn self_leaf_try_accessors_preserve_ownership() {
+		let (mut child, calls) = leaf();
+		assert!(child.try_inner_child().is_none());
+		assert!(unsafe { child.try_inner_child_mut() }.is_none());
+
+		let original = data_ptr(child.as_ref());
+		let child = unsafe { child.try_into_inner_child() }
+			.expect_err("a non-native leaf must be returned");
+		assert_eq!(data_ptr(child.as_ref()), original);
+		assert!(is_type::<Leaf>(child.as_ref()));
+		assert_eq!(calls.inner.load(Ordering::SeqCst), 2);
+		assert_eq!(calls.inner_mut.load(Ordering::SeqCst), 1);
+		assert_eq!(calls.into_inner.load(Ordering::SeqCst), 0);
+		assert_eq!(calls.drops.load(Ordering::SeqCst), 0);
+		drop(child);
+		assert_eq!(calls.drops.load(Ordering::SeqCst), 1);
+	}
+
+	#[tokio::test]
+	async fn nested_non_native_leaf_is_returned_after_layers_are_consumed() {
+		let (leaf, calls) = leaf();
+		let leaf_ptr = data_ptr(leaf.as_ref());
+		let layer_drops = Arc::new(AtomicUsize::new(0));
+		let mut child: Box<dyn ChildWrapper> = Box::new(Layer::tracked(
+			Box::new(Layer::tracked(leaf, Arc::clone(&layer_drops))),
+			Arc::clone(&layer_drops),
+		));
+
+		assert!(child.try_inner_child().is_none());
+		assert!(unsafe { child.try_inner_child_mut() }.is_none());
+		let child = unsafe { child.try_into_inner_child() }
+			.expect_err("the terminal leaf must be returned");
+		assert_eq!(data_ptr(child.as_ref()), leaf_ptr);
+		assert!(is_type::<Leaf>(child.as_ref()));
+		assert_eq!(layer_drops.load(Ordering::SeqCst), 2);
+		assert_eq!(calls.inner.load(Ordering::SeqCst), 2);
+		assert_eq!(calls.inner_mut.load(Ordering::SeqCst), 1);
+		assert_eq!(calls.into_inner.load(Ordering::SeqCst), 0);
+		drop(child);
+		assert_eq!(calls.drops.load(Ordering::SeqCst), 1);
+	}
+
+	#[tokio::test]
+	async fn legacy_accessors_panic_for_non_native_leaves() {
+		let (child, _) = leaf();
+		let panic = catch_unwind(AssertUnwindSafe(|| child.inner_child()))
+			.expect_err("immutable accessor must panic");
+		assert!(panic_text(panic).contains("tokio::process::Child"));
+
+		let (mut child, _) = leaf();
+		let panic = catch_unwind(AssertUnwindSafe(|| unsafe {
+			let _ = child.inner_child_mut();
+		}))
+		.expect_err("mutable accessor must panic");
+		assert!(panic_text(panic).contains("tokio::process::Child"));
+
+		let (child, _) = leaf();
+		let panic = catch_unwind(AssertUnwindSafe(|| unsafe { child.into_inner_child() }))
+			.expect_err("consuming accessor must panic");
+		assert!(panic_text(panic).contains("tokio::process::Child"));
+	}
+
+	#[tokio::test]
+	async fn lifecycle_is_repeatable_through_custom_layers() {
+		let mut child = layered_native();
+		let first = child.wait().await.expect("first wait");
+		let second = child.wait().await.expect("second wait");
+		let third = child
+			.try_wait()
+			.expect("try_wait")
+			.expect("child has exited");
+		assert!(first.success());
+		assert_eq!(first, second);
+		assert_eq!(first, third);
+	}
+
+	#[cfg(all(unix, feature = "process-group"))]
+	#[tokio::test]
+	async fn process_group_exposes_its_immediate_custom_child() {
+		use process_wrap::tokio::ProcessGroup;
+
+		let mut command = wrapped_command();
+		command.wrap(MarkerCommand).wrap(ProcessGroup::leader());
+		let mut child = command.spawn().expect("spawn process group");
+		assert!(is_type::<MarkerChild>(child.inner()));
+		assert!(is_type::<MarkerChild>(child.inner_mut()));
+		let mut child = child.into_inner();
+		assert!(is_type::<MarkerChild>(child.as_ref()));
+		assert!(
+			child
+				.wait()
+				.await
+				.expect("reap process-group child")
+				.success()
+		);
+	}
+
+	#[cfg(all(unix, feature = "process-session"))]
+	#[tokio::test]
+	async fn process_session_exposes_its_immediate_custom_child() {
+		use process_wrap::tokio::ProcessSession;
+
+		let mut command = wrapped_command();
+		command.wrap(MarkerCommand).wrap(ProcessSession);
+		let mut child = command.spawn().expect("spawn process session");
+		assert!(is_type::<MarkerChild>(child.inner()));
+		assert!(is_type::<MarkerChild>(child.inner_mut()));
+		let mut child = child.into_inner();
+		assert!(is_type::<MarkerChild>(child.as_ref()));
+		assert!(
+			child
+				.wait()
+				.await
+				.expect("reap process-session child")
+				.success()
+		);
+	}
+}

--- a/tests/std_unix/into_inner_write_stdin.rs
+++ b/tests/std_unix/into_inner_write_stdin.rs
@@ -7,8 +7,9 @@ fn nowrap() -> Result<()> {
 			command.stdin(Stdio::piped()).stdout(Stdio::piped());
 		})
 		.spawn()?
-		.into_inner_child()
-	};
+		.try_into_inner_child()
+	}
+	.map_err(|_| std::io::Error::other("spawned wrapper chain did not end in a native child"))?;
 
 	if let Some(mut din) = child.stdin.take() {
 		din.write_all(b"hello")?;
@@ -32,8 +33,9 @@ fn process_group() -> Result<()> {
 		})
 		.wrap(ProcessGroup::leader())
 		.spawn()?
-		.into_inner_child()
-	};
+		.try_into_inner_child()
+	}
+	.map_err(|_| std::io::Error::other("spawned wrapper chain did not end in a native child"))?;
 
 	if let Some(mut din) = child.stdin.take() {
 		din.write_all(b"hello")?;
@@ -57,8 +59,9 @@ fn process_session() -> Result<()> {
 		})
 		.wrap(ProcessSession)
 		.spawn()?
-		.into_inner_child()
-	};
+		.try_into_inner_child()
+	}
+	.map_err(|_| std::io::Error::other("spawned wrapper chain did not end in a native child"))?;
 
 	if let Some(mut din) = child.stdin.take() {
 		din.write_all(b"hello")?;

--- a/tests/std_windows/mod.rs
+++ b/tests/std_windows/mod.rs
@@ -17,6 +17,8 @@ mod id_same_as_inner;
 mod inner_read_stdout;
 mod into_inner_write_stdin;
 mod kill_and_try_wait;
+#[cfg(feature = "job-object")]
+mod process_handle;
 mod try_wait_after_die;
 mod wait_after_die;
 mod wait_twice;

--- a/tests/std_windows/process_handle.rs
+++ b/tests/std_windows/process_handle.rs
@@ -1,0 +1,276 @@
+use std::{
+	any::TypeId,
+	os::windows::{
+		io::{AsRawHandle, BorrowedHandle},
+		process::ExitStatusExt,
+	},
+	process::{Command, ExitStatus},
+	sync::{
+		Arc,
+		atomic::{AtomicBool, AtomicUsize, Ordering},
+	},
+};
+
+use super::prelude::*;
+
+#[derive(Debug)]
+struct OpaqueChild {
+	inner_calls: Arc<AtomicUsize>,
+	killed: Arc<AtomicBool>,
+	waited: Arc<AtomicBool>,
+}
+
+impl ChildWrapper for OpaqueChild {
+	fn inner(&self) -> &dyn ChildWrapper {
+		self.inner_calls.fetch_add(1, Ordering::SeqCst);
+		self
+	}
+
+	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+		self
+	}
+
+	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+		self
+	}
+
+	fn start_kill(&mut self) -> Result<()> {
+		self.killed.store(true, Ordering::SeqCst);
+		Ok(())
+	}
+
+	fn wait(&mut self) -> Result<ExitStatus> {
+		self.waited.store(true, Ordering::SeqCst);
+		Ok(ExitStatus::from_raw(0))
+	}
+}
+
+fn opaque_child() -> (
+	Box<dyn ChildWrapper>,
+	Arc<AtomicUsize>,
+	Arc<AtomicBool>,
+	Arc<AtomicBool>,
+) {
+	let inner_calls = Arc::new(AtomicUsize::new(0));
+	let killed = Arc::new(AtomicBool::new(false));
+	let waited = Arc::new(AtomicBool::new(false));
+	(
+		Box::new(OpaqueChild {
+			inner_calls: Arc::clone(&inner_calls),
+			killed: Arc::clone(&killed),
+			waited: Arc::clone(&waited),
+		}),
+		inner_calls,
+		killed,
+		waited,
+	)
+}
+
+#[derive(Debug)]
+struct TransparentChild {
+	inner: Box<dyn ChildWrapper>,
+}
+
+impl ChildWrapper for TransparentChild {
+	fn inner(&self) -> &dyn ChildWrapper {
+		self.inner.as_ref()
+	}
+
+	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+		self.inner.as_mut()
+	}
+
+	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+		self.inner
+	}
+
+	fn process_handle(&self) -> Option<BorrowedHandle<'_>> {
+		self.inner.process_handle()
+	}
+}
+
+#[derive(Debug)]
+struct Transparent;
+
+impl CommandWrapper for Transparent {
+	fn wrap_child(
+		&mut self,
+		child: Box<dyn ChildWrapper>,
+		_core: &CommandWrap,
+	) -> Result<Box<dyn ChildWrapper>> {
+		Ok(Box::new(TransparentChild { inner: child }))
+	}
+}
+
+#[derive(Debug)]
+struct LegacyTransparentChild {
+	inner: Box<dyn ChildWrapper>,
+}
+
+impl ChildWrapper for LegacyTransparentChild {
+	fn inner(&self) -> &dyn ChildWrapper {
+		self.inner.as_ref()
+	}
+
+	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+		self.inner.as_mut()
+	}
+
+	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+		self.inner
+	}
+}
+
+#[derive(Debug)]
+struct LegacyTransparent;
+
+impl CommandWrapper for LegacyTransparent {
+	fn wrap_child(
+		&mut self,
+		child: Box<dyn ChildWrapper>,
+		_core: &CommandWrap,
+	) -> Result<Box<dyn ChildWrapper>> {
+		Ok(Box::new(LegacyTransparentChild { inner: child }))
+	}
+}
+
+#[repr(transparent)]
+#[derive(Debug)]
+struct LegacyInlineChild(std::process::Child);
+
+impl ChildWrapper for LegacyInlineChild {
+	fn inner(&self) -> &dyn ChildWrapper {
+		&self.0
+	}
+
+	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+		&mut self.0
+	}
+
+	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+		Box::new(self.0)
+	}
+}
+
+#[derive(Debug)]
+struct LegacyInline;
+
+impl CommandWrapper for LegacyInline {
+	fn wrap_child(
+		&mut self,
+		child: Box<dyn ChildWrapper>,
+		_core: &CommandWrap,
+	) -> Result<Box<dyn ChildWrapper>> {
+		let child = unsafe { child.try_into_inner_child() }
+			.map_err(|_| std::io::Error::other("legacy inline wrapper expected a native child"))?;
+		Ok(Box::new(LegacyInlineChild(child)))
+	}
+}
+
+fn sleeping_command() -> Command {
+	let mut command = Command::new("cmd.exe");
+	command.args(["/D", "/S", "/C", "ping -n 6 127.0.0.1 >NUL"]);
+	command
+}
+
+fn sleeping_command_wrap() -> CommandWrap {
+	CommandWrap::with_new("cmd.exe", |command| {
+		command.args(["/D", "/S", "/C", "ping -n 6 127.0.0.1 >NUL"]);
+	})
+}
+
+#[test]
+fn opaque_child_defaults_to_no_process_handle_without_traversing() {
+	let (child, inner_calls, _, _) = opaque_child();
+	assert!(child.process_handle().is_none());
+	assert_eq!(inner_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn job_object_rejects_an_opaque_child_and_cleans_it_up() {
+	let (child, inner_calls, killed, waited) = opaque_child();
+	let core = CommandWrap::with_new("cmd.exe", |_| {});
+	let error = JobObject.wrap_child(child, &core).unwrap_err();
+
+	assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+	assert_eq!(inner_calls.load(Ordering::SeqCst), 1);
+	assert!(killed.load(Ordering::SeqCst));
+	assert!(waited.load(Ordering::SeqCst));
+}
+
+#[test]
+fn transparent_child_delegates_the_native_process_handle() -> Result<()> {
+	let native = sleeping_command().spawn()?;
+	let native_handle = native
+		.process_handle()
+		.expect("a native child exposes its process handle")
+		.as_raw_handle();
+	let mut child: Box<dyn ChildWrapper> = Box::new(TransparentChild {
+		inner: Box::new(native),
+	});
+	let delegated_handle = child
+		.process_handle()
+		.expect("a transparent child delegates its process handle")
+		.as_raw_handle();
+
+	child.start_kill()?;
+	let _ = child.wait()?;
+	assert_eq!(delegated_handle, native_handle);
+	Ok(())
+}
+
+#[test]
+fn job_object_falls_back_through_a_legacy_transparent_child() -> Result<()> {
+	let mut command = sleeping_command_wrap();
+	command.wrap(LegacyTransparent).wrap(JobObject);
+	let mut child = command.spawn()?;
+
+	let direct_type = child.inner().type_id();
+	let has_handle = child.process_handle().is_some();
+	child.start_kill()?;
+	let _ = child.wait()?;
+
+	assert_eq!(direct_type, TypeId::of::<LegacyTransparentChild>());
+	assert!(has_handle);
+	Ok(())
+}
+
+#[test]
+fn job_object_falls_back_through_a_legacy_inline_child() -> Result<()> {
+	let mut command = sleeping_command_wrap();
+	command.wrap(LegacyInline).wrap(JobObject);
+	let mut child = command.spawn()?;
+
+	let direct_type = child.inner().type_id();
+	let has_handle = child.process_handle().is_some();
+	child.start_kill()?;
+	let _ = child.wait()?;
+
+	assert_eq!(direct_type, TypeId::of::<LegacyInlineChild>());
+	assert!(has_handle);
+	Ok(())
+}
+
+#[test]
+fn job_object_uses_delegated_handle_and_preserves_the_direct_child() -> Result<()> {
+	let mut command = sleeping_command_wrap();
+	command.wrap(Transparent).wrap(JobObject);
+	let mut child = command.spawn()?;
+
+	let outer_has_handle = child.process_handle().is_some();
+	let direct_type = child.inner().type_id();
+	let direct_mut_type = child.inner_mut().type_id();
+	let mut direct = child.into_inner();
+	let consumed_type = direct.as_ref().type_id();
+	let consumed_has_handle = direct.process_handle().is_some();
+
+	direct.start_kill()?;
+	let _ = direct.wait()?;
+
+	assert!(outer_has_handle);
+	assert_eq!(direct_type, TypeId::of::<TransparentChild>());
+	assert_eq!(direct_mut_type, TypeId::of::<TransparentChild>());
+	assert_eq!(consumed_type, TypeId::of::<TransparentChild>());
+	assert!(consumed_has_handle);
+	Ok(())
+}

--- a/tests/tokio_windows/mod.rs
+++ b/tests/tokio_windows/mod.rs
@@ -18,6 +18,8 @@ mod into_inner_write_stdin;
 #[cfg(all(feature = "job-object", feature = "kill-on-drop"))]
 mod job_object_kill_on_drop;
 mod kill_and_try_wait;
+#[cfg(feature = "job-object")]
+mod process_handle;
 mod try_wait_after_die;
 mod wait_after_die;
 mod wait_twice;

--- a/tests/tokio_windows/process_handle.rs
+++ b/tests/tokio_windows/process_handle.rs
@@ -1,0 +1,257 @@
+use std::{
+	any::TypeId,
+	os::windows::io::{AsRawHandle, BorrowedHandle},
+	sync::{
+		Arc,
+		atomic::{AtomicBool, AtomicUsize, Ordering},
+	},
+};
+
+use super::prelude::*;
+
+#[derive(Debug)]
+struct OpaqueChild {
+	inner_calls: Arc<AtomicUsize>,
+	killed: Arc<AtomicBool>,
+}
+
+impl ChildWrapper for OpaqueChild {
+	fn inner(&self) -> &dyn ChildWrapper {
+		self.inner_calls.fetch_add(1, Ordering::SeqCst);
+		self
+	}
+
+	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+		self
+	}
+
+	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+		self
+	}
+
+	fn start_kill(&mut self) -> Result<()> {
+		self.killed.store(true, Ordering::SeqCst);
+		Ok(())
+	}
+}
+
+fn opaque_child() -> (Box<dyn ChildWrapper>, Arc<AtomicUsize>, Arc<AtomicBool>) {
+	let inner_calls = Arc::new(AtomicUsize::new(0));
+	let killed = Arc::new(AtomicBool::new(false));
+	(
+		Box::new(OpaqueChild {
+			inner_calls: Arc::clone(&inner_calls),
+			killed: Arc::clone(&killed),
+		}),
+		inner_calls,
+		killed,
+	)
+}
+
+#[derive(Debug)]
+struct TransparentChild {
+	inner: Box<dyn ChildWrapper>,
+}
+
+impl ChildWrapper for TransparentChild {
+	fn inner(&self) -> &dyn ChildWrapper {
+		self.inner.as_ref()
+	}
+
+	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+		self.inner.as_mut()
+	}
+
+	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+		self.inner
+	}
+
+	fn process_handle(&self) -> Option<BorrowedHandle<'_>> {
+		self.inner.process_handle()
+	}
+}
+
+#[derive(Debug)]
+struct Transparent;
+
+impl CommandWrapper for Transparent {
+	fn wrap_child(
+		&mut self,
+		child: Box<dyn ChildWrapper>,
+		_core: &CommandWrap,
+	) -> Result<Box<dyn ChildWrapper>> {
+		Ok(Box::new(TransparentChild { inner: child }))
+	}
+}
+
+#[derive(Debug)]
+struct LegacyTransparentChild {
+	inner: Box<dyn ChildWrapper>,
+}
+
+impl ChildWrapper for LegacyTransparentChild {
+	fn inner(&self) -> &dyn ChildWrapper {
+		self.inner.as_ref()
+	}
+
+	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+		self.inner.as_mut()
+	}
+
+	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+		self.inner
+	}
+}
+
+#[derive(Debug)]
+struct LegacyTransparent;
+
+impl CommandWrapper for LegacyTransparent {
+	fn wrap_child(
+		&mut self,
+		child: Box<dyn ChildWrapper>,
+		_core: &CommandWrap,
+	) -> Result<Box<dyn ChildWrapper>> {
+		Ok(Box::new(LegacyTransparentChild { inner: child }))
+	}
+}
+
+#[repr(transparent)]
+#[derive(Debug)]
+struct LegacyInlineChild(tokio::process::Child);
+
+impl ChildWrapper for LegacyInlineChild {
+	fn inner(&self) -> &dyn ChildWrapper {
+		&self.0
+	}
+
+	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+		&mut self.0
+	}
+
+	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+		Box::new(self.0)
+	}
+}
+
+#[derive(Debug)]
+struct LegacyInline;
+
+impl CommandWrapper for LegacyInline {
+	fn wrap_child(
+		&mut self,
+		child: Box<dyn ChildWrapper>,
+		_core: &CommandWrap,
+	) -> Result<Box<dyn ChildWrapper>> {
+		let child = unsafe { child.try_into_inner_child() }
+			.map_err(|_| std::io::Error::other("legacy inline wrapper expected a native child"))?;
+		Ok(Box::new(LegacyInlineChild(child)))
+	}
+}
+
+fn sleeping_command() -> tokio::process::Command {
+	let mut command = tokio::process::Command::new("cmd.exe");
+	command.args(["/D", "/S", "/C", "ping -n 6 127.0.0.1 >NUL"]);
+	command
+}
+
+fn sleeping_command_wrap() -> CommandWrap {
+	CommandWrap::with_new("cmd.exe", |command| {
+		command.args(["/D", "/S", "/C", "ping -n 6 127.0.0.1 >NUL"]);
+	})
+}
+
+#[test]
+fn opaque_child_defaults_to_no_process_handle_without_traversing() {
+	let (child, inner_calls, _) = opaque_child();
+	assert!(child.process_handle().is_none());
+	assert_eq!(inner_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn job_object_rejects_an_opaque_child_and_cleans_it_up() {
+	let (child, inner_calls, killed) = opaque_child();
+	let core = CommandWrap::with_new("cmd.exe", |_| {});
+	let error = JobObject.wrap_child(child, &core).unwrap_err();
+
+	assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+	assert_eq!(inner_calls.load(Ordering::SeqCst), 1);
+	assert!(killed.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn transparent_child_delegates_the_native_process_handle() -> Result<()> {
+	let native = sleeping_command().spawn()?;
+	let native_handle = native
+		.process_handle()
+		.expect("a native child exposes its process handle")
+		.as_raw_handle();
+	let mut child: Box<dyn ChildWrapper> = Box::new(TransparentChild {
+		inner: Box::new(native),
+	});
+	let delegated_handle = child
+		.process_handle()
+		.expect("a transparent child delegates its process handle")
+		.as_raw_handle();
+
+	child.start_kill()?;
+	let _ = child.wait().await?;
+	assert_eq!(delegated_handle, native_handle);
+	Ok(())
+}
+
+#[tokio::test]
+async fn job_object_falls_back_through_a_legacy_transparent_child() -> Result<()> {
+	let mut command = sleeping_command_wrap();
+	command.wrap(LegacyTransparent).wrap(JobObject);
+	let mut child = command.spawn()?;
+
+	let direct_type = child.inner().type_id();
+	let has_handle = child.process_handle().is_some();
+	child.start_kill()?;
+	let _ = child.wait().await?;
+
+	assert_eq!(direct_type, TypeId::of::<LegacyTransparentChild>());
+	assert!(has_handle);
+	Ok(())
+}
+
+#[tokio::test]
+async fn job_object_falls_back_through_a_legacy_inline_child() -> Result<()> {
+	let mut command = sleeping_command_wrap();
+	command.wrap(LegacyInline).wrap(JobObject);
+	let mut child = command.spawn()?;
+
+	let direct_type = child.inner().type_id();
+	let has_handle = child.process_handle().is_some();
+	child.start_kill()?;
+	let _ = child.wait().await?;
+
+	assert_eq!(direct_type, TypeId::of::<LegacyInlineChild>());
+	assert!(has_handle);
+	Ok(())
+}
+
+#[tokio::test]
+async fn job_object_uses_delegated_handle_and_preserves_the_direct_child() -> Result<()> {
+	let mut command = sleeping_command_wrap();
+	command.wrap(Transparent).wrap(JobObject);
+	let mut child = command.spawn()?;
+
+	let outer_has_handle = child.process_handle().is_some();
+	let direct_type = child.inner().type_id();
+	let direct_mut_type = child.inner_mut().type_id();
+	let mut direct = child.into_inner();
+	let consumed_type = direct.as_ref().type_id();
+	let consumed_has_handle = direct.process_handle().is_some();
+
+	direct.start_kill()?;
+	let _ = direct.wait().await?;
+
+	assert!(outer_has_handle);
+	assert_eq!(direct_type, TypeId::of::<TransparentChild>());
+	assert_eq!(direct_mut_type, TypeId::of::<TransparentChild>());
+	assert_eq!(consumed_type, TypeId::of::<TransparentChild>());
+	assert!(consumed_has_handle);
+	Ok(())
+}


### PR DESCRIPTION
Replace panicking native-child accessors with fallible traversal that preserves non-native terminal children. Also:

- add object-safe Windows process access and use it for `JobObject` assignment
- return `Unsupported` when a custom child cannot be assigned to a `JobObject`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
