### PR TITLE
feat: add Tokio PTY support on Unix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,52 @@ jobs:
       - run: tests/multiproc_helper.rs 1 1
       - run: cargo test --locked --all-features --all-targets
 
+  portable-unix-pty:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-linux-android
+            toolchain: stable
+          - target: x86_64-unknown-freebsd
+            toolchain: stable
+          - target: x86_64-unknown-netbsd
+            toolchain: stable
+          - target: x86_64-unknown-illumos
+            toolchain: stable
+          - target: x86_64-pc-solaris
+            toolchain: stable
+          - target: x86_64-unknown-dragonfly
+            toolchain: nightly
+          - target: x86_64-unknown-openbsd
+            toolchain: nightly
+
+    name: "Check PTY on ${{ matrix.target }}"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Configure Rust
+        run: |
+          rustup toolchain install --profile minimal --no-self-update ${{ matrix.toolchain }}
+          rustup default ${{ matrix.toolchain }}
+          if [ "${{ matrix.toolchain }}" = nightly ]; then
+            rustup component add rust-src
+          else
+            rustup target add "${{ matrix.target }}"
+          fi
+
+      - name: Check portable Unix PTY backend
+        run: |
+          if [ "${{ matrix.toolchain }}" = nightly ]; then
+            cargo check --locked -Zbuild-std=std --target "${{ matrix.target }}" --no-default-features --features pty --lib
+          else
+            cargo check --locked --target "${{ matrix.target }}" --no-default-features --features pty --lib
+          fi
+
   rustdoc:
     name: Rustdoc
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         features:
           - tokio1
           - std
+          - pty
 
     name: "Test on ${{ matrix.platform }} with Rust ${{ matrix.toolchain }} (feat: ${{ matrix.features }})"
     runs-on: "${{ matrix.platform }}-latest"
@@ -111,6 +112,30 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --locked --all-features --no-deps
+
+  package:
+    name: Package contents
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Configure Rust
+        run: |
+          rustup toolchain install --profile minimal --no-self-update stable
+          rustup default stable
+
+      - name: Build the packaged crate with every feature
+        run: cargo package --locked --all-features
+
+      - name: Check packaged PTY sources
+        run: |
+          cargo package --locked --no-verify --list > "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/unix.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/unsupported.rs' "$RUNNER_TEMP/package-files.txt"
 
   semver:
     name: Semver against PR base

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +774,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,13 @@ reset-sigmask = []
 [package.metadata.docs.rs]
 all-features = true
 targets = [
+    "aarch64-linux-android",
     "x86_64-unknown-linux-gnu",
     "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+    "x86_64-unknown-illumos",
+    "x86_64-pc-solaris",
     "x86_64-pc-windows-msvc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ std = ["dep:nix"]
 ## Frontend: TokioCommandWrap
 tokio1 = ["dep:nix", "dep:futures", "dep:tokio"]
 
+## Tokio pseudo-terminal transport
+pty = ["tokio1", "nix/term", "tokio/net"]
+
 ## Wrapper: Creation Flags
 creation-flags = ["dep:windows", "windows/Win32_System_Threading"]
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,52 @@ let status = child.wait().await?;
 dbg!(status);
 ```
 
+### or in a pseudo-terminal
+
+The non-default `pty` feature enables Tokio PTY transport on Linux and macOS. It implies `tokio1`.
+Other targets return `std::io::ErrorKind::Unsupported` rather than falling back to ordinary pipes.
+
+```toml
+[dependencies]
+process-wrap = { version = "9.1.0", features = ["pty"] }
+```
+
+```rust
+use process_wrap::tokio::*;
+use tokio::io::AsyncReadExt;
+
+let mut command = PtyCommand::new("ls");
+command.wrap(ProcessSession);
+let (mut child, controller) = command.spawn(PtyOptions::default())?;
+let (input, mut output, _resize) = controller.into_parts();
+drop(input);
+
+let drain = tokio::spawn(async move {
+  let mut bytes = Vec::new();
+  output.read_to_end(&mut bytes).await?;
+  Ok::<_, std::io::Error>(bytes)
+});
+let status = child.wait().await?;
+let terminal_bytes = drain.await??;
+dbg!(status, terminal_bytes);
+```
+
+A PTY intentionally merges stdout and stderr. `PtyInput` and `PtyOutput` are strong owners of one
+bidirectional master descriptor, so dropping either one alone does not half-close the terminal. The
+terminal hangs up after both are gone; `PtyResize` is weak and cannot keep it alive. Send the
+terminal's VEOF character when that is the desired terminal policy rather than expecting a separate
+input half-close or clonable force-close handle.
+
+Child waiting and PTY draining are independent: descendants can retain the slave after the direct
+child exits. The transport passes terminal bytes through without owning parent-terminal raw mode,
+relays, key handling, VT parsing, scrollback, or pager policy.
+
+A bare PTY creates the required session. `ProcessGroup::leader()` and `ProcessSession` each preserve
+their group-aware child supervision when used individually; `ProcessGroup::attach_to(...)` and
+explicitly registering both wrappers return `InvalidInput`. `ResetSigmask` composes normally.
+`KillOnDrop` remains Tokio's direct-child behavior—it does not promise to kill an entire group or
+session.
+
 ### or with std
 
 ```toml
@@ -256,6 +302,8 @@ Refer to [the API documentation][docs] for more detail and the specifics of chil
 
 - `std`: enables the std-based API.
 - `tokio1`: enables the Tokio-based API.
+- `pty`: enables the Tokio [pseudo-terminal transport](#or-in-a-pseudo-terminal) and implies
+  `tokio1`.
 
 Both can exist at the same time, but generally you should use one or the other.
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ dbg!(status);
 
 ### or in a pseudo-terminal
 
-The non-default `pty` feature enables Tokio PTY transport on Linux and macOS. It implies `tokio1`.
-Other targets return `std::io::ErrorKind::Unsupported` rather than falling back to ordinary pipes.
+The non-default `pty` feature enables Tokio PTY transport on Linux, Android, macOS, FreeBSD,
+NetBSD, OpenBSD, DragonFly BSD, illumos, and Solaris. It implies `tokio1`. Other targets return
+`std::io::ErrorKind::Unsupported` rather than falling back to ordinary pipes. Linux and macOS run
+transport tests in CI; the other Unix backends are cross-compiled there pending native runners.
 
 ```toml
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ terminal hangs up after both are gone; `PtyResize` is weak and cannot keep it al
 terminal's VEOF character when that is the desired terminal policy rather than expecting a separate
 input half-close or clonable force-close handle.
 
-Child waiting and PTY draining are independent: descendants can retain the slave after the direct
-child exits. The transport passes terminal bytes through without owning parent-terminal raw mode,
+Child waiting and PTY draining are independent. On most supported Unix systems, descendants can retain
+the slave after the direct child exits. On macOS, drain output concurrently with waiting: the kernel
+drains queued output as the session leader exits, then revokes the controlling terminal from its
+descendants. The transport passes terminal bytes through without owning parent-terminal raw mode,
 relays, key handling, VT parsing, scrollback, or pager policy.
 
 A bare PTY creates the required session. `ProcessGroup::leader()` and `ProcessSession` each preserve

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,10 @@
 //! # Overview
 //!
 //! This crate provides a composable set of wrappers over `process::Command` (either from std or
-//! from Tokio). It is a more flexible and composable successor to the `command-group` crate, and is
-//! meant to be adaptable to additional use cases: for example spawning processes in PTYs currently
-//! requires a different crate (such as `pty-process`) which won't function with `command-group`.
-//! Implementing a PTY wrapper for `process-wrap` would instead keep the same API and be composable
-//! with the existing process group/session implementations.
+//! from Tokio). It is a more flexible and composable successor to the `command-group` crate. With
+//! the non-default `pty` feature, [`tokio::PtyCommand`] also spawns Tokio processes in native
+//! pseudo-terminals on Linux and macOS while retaining the same child-wrapper and process
+//! group/session supervision APIs.
 //!
 //! # Usage
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@
 //! This crate provides a composable set of wrappers over `process::Command` (either from std or
 //! from Tokio). It is a more flexible and composable successor to the `command-group` crate. With
 //! the non-default `pty` feature, [`tokio::PtyCommand`] also spawns Tokio processes in native
-//! pseudo-terminals on Linux and macOS while retaining the same child-wrapper and process
-//! group/session supervision APIs.
+//! pseudo-terminals on Linux, Android, macOS, the BSDs, illumos, and Solaris while retaining the same
+//! child-wrapper and process group/session supervision APIs.
 //!
 //! # Usage
 //!

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -25,6 +25,10 @@ pub use process_group::{ProcessGroup, ProcessGroupChild};
 #[cfg(all(unix, feature = "process-session"))]
 #[doc(inline)]
 pub use process_session::ProcessSession;
+#[cfg(feature = "pty")]
+#[doc(inline)]
+/// Pseudo-terminal support, available with the non-default `pty` crate feature.
+pub use pty::{PtyCommand, PtyController, PtyInput, PtyOptions, PtyOutput, PtyResize, PtySize};
 #[cfg(all(unix, feature = "reset-sigmask"))]
 #[doc(inline)]
 pub use reset_sigmask::ResetSigmask;
@@ -40,5 +44,7 @@ mod kill_on_drop;
 mod process_group;
 #[cfg(all(unix, feature = "process-session"))]
 mod process_session;
+#[cfg(feature = "pty")]
+mod pty;
 #[cfg(all(unix, feature = "reset-sigmask"))]
 mod reset_sigmask;

--- a/src/tokio/kill_on_drop.rs
+++ b/src/tokio/kill_on_drop.rs
@@ -9,6 +9,10 @@ use super::{CommandWrap, CommandWrapper};
 /// This wrapper exists to be able to set the kill-on-drop flag on a `Command` and also store that
 /// fact in the wrapper, so that it can be used by other wrappers. Notably this is used by the
 /// `JobObject` wrapper.
+///
+/// On Unix, dropping a process-group or session child still applies Tokio's kill-on-drop behavior to
+/// the direct native child only. Use the group-aware child's explicit kill or signal methods when
+/// the entire process group must be targeted.
 #[derive(Clone, Copy, Debug)]
 pub struct KillOnDrop;
 

--- a/src/tokio/process_group.rs
+++ b/src/tokio/process_group.rs
@@ -1,3 +1,5 @@
+#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+use std::io::ErrorKind;
 use std::{
 	future::Future,
 	io::{Error, Result},
@@ -22,6 +24,8 @@ use tracing::instrument;
 
 use crate::ChildExitStatus;
 
+#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+use super::pty::PtyMarker;
 use super::{ChildWrapper, CommandWrap, CommandWrapper};
 
 /// Wrapper which sets the process group of a `Command`.
@@ -38,6 +42,8 @@ use super::{ChildWrapper, CommandWrap, CommandWrapper};
 #[derive(Clone, Copy, Debug)]
 pub struct ProcessGroup {
 	leader: Pid,
+	#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+	attach: bool,
 }
 
 impl ProcessGroup {
@@ -45,6 +51,8 @@ impl ProcessGroup {
 	pub fn leader() -> Self {
 		Self {
 			leader: Pid::from_raw(0),
+			#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+			attach: false,
 		}
 	}
 
@@ -52,6 +60,8 @@ impl ProcessGroup {
 	pub fn attach_to(leader: u32) -> Self {
 		Self {
 			leader: Pid::from_raw(leader as i32),
+			#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+			attach: true,
 		}
 	}
 }
@@ -85,6 +95,24 @@ impl ProcessGroupChild {
 impl CommandWrapper for ProcessGroup {
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn pre_spawn(&mut self, command: &mut Command, _core: &CommandWrap) -> Result<()> {
+		#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+		if _core.has_wrap::<PtyMarker>() {
+			#[cfg(feature = "process-session")]
+			if _core.has_wrap::<super::ProcessSession>() {
+				return Err(Error::new(
+					ErrorKind::InvalidInput,
+					"ProcessGroup and ProcessSession cannot both be used with a PTY",
+				));
+			}
+			if self.attach {
+				return Err(Error::new(
+					ErrorKind::InvalidInput,
+					"ProcessGroup::attach_to cannot be used with a PTY",
+				));
+			}
+			return Ok(());
+		}
+
 		command.process_group(self.leader.as_raw());
 		Ok(())
 	}
@@ -210,21 +238,14 @@ impl ChildWrapper for ProcessGroupChild {
 			return Ok(Some(*status));
 		}
 
-		match Self::wait_imp(self.pgid, WaitPidFlag::WNOHANG)? {
-			ControlFlow::Break(res) => {
-				if let Some(status) = res {
-					self.exit_status = ChildExitStatus::Exited(status);
-				}
-				Ok(res)
-			}
-			ControlFlow::Continue(()) => {
-				let exited = self.inner.try_wait()?;
-				if let Some(exited) = exited {
-					self.exit_status = ChildExitStatus::Exited(exited);
-				}
-				Ok(exited)
-			}
+		let exited = self.inner.try_wait()?;
+		if let Some(status) = exited {
+			self.exit_status = ChildExitStatus::Exited(status);
+			// The native child must reap the leader so its own cached state remains synchronized.
+			// Once that has happened, opportunistically reap any exited descendants in the group.
+			let _ = Self::wait_imp(self.pgid, WaitPidFlag::WNOHANG)?;
 		}
+		Ok(exited)
 	}
 
 	fn signal(&self, sig: i32) -> Result<()> {

--- a/src/tokio/process_group.rs
+++ b/src/tokio/process_group.rs
@@ -38,6 +38,11 @@ use super::{ChildWrapper, CommandWrap, CommandWrapper};
 /// Process groups direct signals to all members of the group, and also serve to control job
 /// placement in foreground or background, among other actions.
 ///
+/// With a supported Unix `PtyCommand`, [`leader`](Self::leader) leaves session and process-group
+/// creation to the PTY backend while retaining group-aware child supervision. Attaching a new PTY
+/// session to an existing group is invalid, so [`attach_to`](Self::attach_to) causes PTY spawning to
+/// return [`std::io::ErrorKind::InvalidInput`].
+///
 /// This wrapper provides a child wrapper: [`ProcessGroupChild`].
 #[derive(Clone, Copy, Debug)]
 pub struct ProcessGroup {

--- a/src/tokio/process_group.rs
+++ b/src/tokio/process_group.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+#[cfg(feature = "pty")]
 use std::io::ErrorKind;
 use std::{
 	future::Future,
@@ -24,7 +24,7 @@ use tracing::instrument;
 
 use crate::ChildExitStatus;
 
-#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+#[cfg(feature = "pty")]
 use super::pty::PtyMarker;
 use super::{ChildWrapper, CommandWrap, CommandWrapper};
 
@@ -47,7 +47,7 @@ use super::{ChildWrapper, CommandWrap, CommandWrapper};
 #[derive(Clone, Copy, Debug)]
 pub struct ProcessGroup {
 	leader: Pid,
-	#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+	#[cfg(feature = "pty")]
 	attach: bool,
 }
 
@@ -56,7 +56,7 @@ impl ProcessGroup {
 	pub fn leader() -> Self {
 		Self {
 			leader: Pid::from_raw(0),
-			#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+			#[cfg(feature = "pty")]
 			attach: false,
 		}
 	}
@@ -65,7 +65,7 @@ impl ProcessGroup {
 	pub fn attach_to(leader: u32) -> Self {
 		Self {
 			leader: Pid::from_raw(leader as i32),
-			#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+			#[cfg(feature = "pty")]
 			attach: true,
 		}
 	}
@@ -100,7 +100,7 @@ impl ProcessGroupChild {
 impl CommandWrapper for ProcessGroup {
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn pre_spawn(&mut self, command: &mut Command, _core: &CommandWrap) -> Result<()> {
-		#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+		#[cfg(feature = "pty")]
 		if _core.has_wrap::<PtyMarker>() {
 			#[cfg(feature = "process-session")]
 			if _core.has_wrap::<super::ProcessSession>() {

--- a/src/tokio/process_session.rs
+++ b/src/tokio/process_session.rs
@@ -1,3 +1,5 @@
+#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+use std::io::ErrorKind;
 use std::io::{Error, Result};
 
 use nix::unistd::{Pid, setsid};
@@ -5,6 +7,8 @@ use tokio::process::Command;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
+#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+use super::pty::PtyMarker;
 use super::{CommandWrap, CommandWrapper};
 
 /// Wrapper which creates a new session and group for the `Command`.
@@ -25,6 +29,17 @@ pub struct ProcessSession;
 impl CommandWrapper for ProcessSession {
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn pre_spawn(&mut self, command: &mut Command, _core: &CommandWrap) -> Result<()> {
+		#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+		if _core.has_wrap::<PtyMarker>() {
+			if _core.has_wrap::<super::ProcessGroup>() {
+				return Err(Error::new(
+					ErrorKind::InvalidInput,
+					"ProcessGroup and ProcessSession cannot both be used with a PTY",
+				));
+			}
+			return Ok(());
+		}
+
 		unsafe {
 			command.pre_exec(move || setsid().map_err(Error::from).map(|_| ()));
 		}

--- a/src/tokio/process_session.rs
+++ b/src/tokio/process_session.rs
@@ -23,6 +23,10 @@ use super::{CommandWrap, CommandWrapper};
 ///
 /// This wrapper uses [the same child wrapper as `ProcessGroup`](super::ProcessGroupChild) and does
 /// the same setup (plus the session setup); using both together is unnecessary and may misbehave.
+///
+/// With a supported Unix `PtyCommand`, the PTY backend performs the required session setup and this
+/// wrapper retains its group-aware child supervision. Explicitly registering both `ProcessGroup`
+/// and `ProcessSession` for a PTY is ambiguous and returns [`std::io::ErrorKind::InvalidInput`].
 #[derive(Clone, Copy, Debug)]
 pub struct ProcessSession;
 

--- a/src/tokio/process_session.rs
+++ b/src/tokio/process_session.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+#[cfg(feature = "pty")]
 use std::io::ErrorKind;
 use std::io::{Error, Result};
 
@@ -7,7 +7,7 @@ use tokio::process::Command;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
-#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+#[cfg(feature = "pty")]
 use super::pty::PtyMarker;
 use super::{CommandWrap, CommandWrapper};
 
@@ -33,7 +33,7 @@ pub struct ProcessSession;
 impl CommandWrapper for ProcessSession {
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn pre_spawn(&mut self, command: &mut Command, _core: &CommandWrap) -> Result<()> {
-		#[cfg(all(feature = "pty", any(target_os = "linux", target_os = "macos")))]
+		#[cfg(feature = "pty")]
 		if _core.has_wrap::<PtyMarker>() {
 			if _core.has_wrap::<super::ProcessGroup>() {
 				return Err(Error::new(

--- a/src/tokio/pty.rs
+++ b/src/tokio/pty.rs
@@ -375,9 +375,10 @@ impl AsyncWrite for PtyInput {
 
 /// The asynchronous merged output side of a pseudo-terminal.
 ///
-/// This is a strong owner of the shared bidirectional PTY master. Output EOF means that every slave
-/// descriptor has closed; it is independent from waiting for the direct child because a descendant
-/// may retain the slave after that child exits.
+/// This is a strong owner of the shared bidirectional PTY master. On most supported Unix systems,
+/// output EOF means that every slave descriptor has closed and a descendant may retain the slave
+/// after the direct child exits. On macOS, drain output concurrently with waiting: session-leader
+/// exit drains queued output and then revokes the controlling terminal from its descendants.
 #[derive(Debug)]
 pub struct PtyOutput {
 	inner: imp::Output,
@@ -420,7 +421,9 @@ impl PtyResize {
 /// or pager policy in this transport.
 ///
 /// Process supervision and PTY draining are separate lifecycles. Waiting for the direct child does
-/// not imply output EOF, because descendants can retain slave descriptors.
+/// not imply output EOF on most supported Unix systems, because descendants can retain slave
+/// descriptors. On macOS, drive waiting and draining concurrently because session-leader exit waits
+/// for queued output before revoking the controlling terminal.
 #[derive(Debug)]
 pub struct PtyController {
 	input: PtyInput,

--- a/src/tokio/pty.rs
+++ b/src/tokio/pty.rs
@@ -151,6 +151,13 @@ impl CommandIntent {
 	}
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[derive(Clone, Copy, Debug)]
+pub(super) struct PtyMarker;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl CommandWrapper for PtyMarker {}
+
 /// A tracked command builder for pseudo-terminal spawning.
 ///
 /// The builder owns the complete portable command intent instead of exposing unrestricted mutable

--- a/src/tokio/pty.rs
+++ b/src/tokio/pty.rs
@@ -1,0 +1,390 @@
+use std::{
+	ffi::{OsStr, OsString},
+	io,
+	path::Path,
+	pin::Pin,
+	task::{Context, Poll},
+};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use super::{ChildWrapper, CommandWrap, CommandWrapper};
+
+mod unsupported;
+use unsupported as imp;
+
+/// The character and pixel dimensions of a pseudo-terminal.
+///
+/// Character dimensions must both be nonzero. Pixel dimensions may be zero when they are unknown or
+/// not meaningful to the caller. Sizes are validated by [`PtyCommand::spawn`] and
+/// [`PtyResize::resize`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PtySize {
+	/// Character rows.
+	pub rows: u16,
+	/// Character columns.
+	pub columns: u16,
+	/// Pixel width, or zero when unspecified.
+	pub pixel_width: u16,
+	/// Pixel height, or zero when unspecified.
+	pub pixel_height: u16,
+}
+
+impl PtySize {
+	/// Construct a character-cell size with unspecified pixel dimensions.
+	pub fn new(rows: u16, columns: u16) -> io::Result<Self> {
+		let size = Self {
+			rows,
+			columns,
+			pixel_width: 0,
+			pixel_height: 0,
+		};
+		size.validate()?;
+		Ok(size)
+	}
+
+	/// Set the optional pixel dimensions.
+	pub fn with_pixels(mut self, pixel_width: u16, pixel_height: u16) -> Self {
+		self.pixel_width = pixel_width;
+		self.pixel_height = pixel_height;
+		self
+	}
+
+	/// Validate that both character dimensions are nonzero.
+	pub fn validate(self) -> io::Result<()> {
+		if self.rows == 0 || self.columns == 0 {
+			return Err(io::Error::new(
+				io::ErrorKind::InvalidInput,
+				"PTY rows and columns must both be nonzero",
+			));
+		}
+		Ok(())
+	}
+}
+
+impl Default for PtySize {
+	fn default() -> Self {
+		Self {
+			rows: 24,
+			columns: 80,
+			pixel_width: 0,
+			pixel_height: 0,
+		}
+	}
+}
+
+/// Options used when spawning a command in a pseudo-terminal.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PtyOptions {
+	/// Initial terminal size.
+	pub size: PtySize,
+}
+
+impl PtyOptions {
+	/// Construct options with the requested initial terminal size.
+	pub fn new(size: PtySize) -> Self {
+		Self { size }
+	}
+}
+
+#[derive(Debug)]
+enum CommandArg {
+	Regular(OsString),
+	#[cfg(windows)]
+	Raw(OsString),
+}
+
+#[derive(Debug)]
+enum EnvChange {
+	Set(OsString, OsString),
+	Remove(OsString),
+}
+
+#[derive(Debug)]
+struct CommandIntent {
+	program: OsString,
+	args: Vec<CommandArg>,
+	env_clear: bool,
+	env: Vec<EnvChange>,
+	current_dir: Option<OsString>,
+}
+
+impl CommandIntent {
+	fn command(&self) -> tokio::process::Command {
+		let mut command = tokio::process::Command::new(&self.program);
+		for arg in &self.args {
+			match arg {
+				CommandArg::Regular(arg) => {
+					command.arg(arg);
+				}
+				#[cfg(windows)]
+				CommandArg::Raw(arg) => {
+					command.raw_arg(arg);
+				}
+			}
+		}
+
+		if self.env_clear {
+			command.env_clear();
+		}
+		for change in &self.env {
+			match change {
+				EnvChange::Set(key, value) => {
+					command.env(key, value);
+				}
+				EnvChange::Remove(key) => {
+					command.env_remove(key);
+				}
+			}
+		}
+		if let Some(directory) = &self.current_dir {
+			command.current_dir(directory);
+		}
+		command
+	}
+}
+
+/// A tracked command builder for pseudo-terminal spawning.
+///
+/// The builder owns the complete portable command intent instead of exposing unrestricted mutable
+/// access to the underlying Tokio command. This lets platform backends preserve arguments,
+/// environment operations, the working directory, and wrapper registration exactly.
+#[derive(Debug)]
+pub struct PtyCommand {
+	command: CommandWrap,
+	intent: CommandIntent,
+}
+
+impl PtyCommand {
+	/// Construct a pseudo-terminal command builder for a program.
+	pub fn new(program: impl AsRef<OsStr>) -> Self {
+		let program = program.as_ref().to_os_string();
+		Self {
+			command: CommandWrap::with_new(&program, |_| {}),
+			intent: CommandIntent {
+				program,
+				args: Vec::new(),
+				env_clear: false,
+				env: Vec::new(),
+				current_dir: None,
+			},
+		}
+	}
+
+	/// Replace the program to execute.
+	pub fn program(&mut self, program: impl AsRef<OsStr>) -> &mut Self {
+		self.intent.program = program.as_ref().to_os_string();
+		self
+	}
+
+	/// Append one argument using the platform command's normal argument semantics.
+	pub fn arg(&mut self, arg: impl AsRef<OsStr>) -> &mut Self {
+		self.intent
+			.args
+			.push(CommandArg::Regular(arg.as_ref().to_os_string()));
+		self
+	}
+
+	/// Append arguments using the platform command's normal argument semantics.
+	pub fn args<I, S>(&mut self, args: I) -> &mut Self
+	where
+		I: IntoIterator<Item = S>,
+		S: AsRef<OsStr>,
+	{
+		for arg in args {
+			self.arg(arg);
+		}
+		self
+	}
+
+	/// Append a raw command-line fragment on Windows.
+	///
+	/// Raw fragments are preserved in their registration order relative to regular arguments.
+	#[cfg(windows)]
+	pub fn raw_arg(&mut self, arg: impl AsRef<OsStr>) -> &mut Self {
+		self.intent
+			.args
+			.push(CommandArg::Raw(arg.as_ref().to_os_string()));
+		self
+	}
+
+	/// Set an environment variable for the child.
+	pub fn env(&mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> &mut Self {
+		self.intent.env.push(EnvChange::Set(
+			key.as_ref().to_os_string(),
+			value.as_ref().to_os_string(),
+		));
+		self
+	}
+
+	/// Set environment variables for the child.
+	pub fn envs<I, K, V>(&mut self, variables: I) -> &mut Self
+	where
+		I: IntoIterator<Item = (K, V)>,
+		K: AsRef<OsStr>,
+		V: AsRef<OsStr>,
+	{
+		for (key, value) in variables {
+			self.env(key, value);
+		}
+		self
+	}
+
+	/// Remove an inherited or explicitly set environment variable.
+	pub fn env_remove(&mut self, key: impl AsRef<OsStr>) -> &mut Self {
+		self.intent
+			.env
+			.push(EnvChange::Remove(key.as_ref().to_os_string()));
+		self
+	}
+
+	/// Clear the inherited environment and all prior environment changes.
+	pub fn env_clear(&mut self) -> &mut Self {
+		self.intent.env_clear = true;
+		self.intent.env.clear();
+		self
+	}
+
+	/// Set the child's working directory.
+	pub fn current_dir(&mut self, directory: impl AsRef<Path>) -> &mut Self {
+		self.intent.current_dir = Some(directory.as_ref().as_os_str().to_os_string());
+		self
+	}
+
+	/// Register a process wrapper.
+	pub fn wrap<W: CommandWrapper + 'static>(&mut self, wrapper: W) -> &mut Self {
+		self.command.wrap(wrapper);
+		self
+	}
+
+	/// Spawn the command attached to a pseudo-terminal.
+	///
+	/// This API never falls back to ordinary pipes. On a target without a backend it returns
+	/// [`io::ErrorKind::Unsupported`].
+	pub fn spawn(
+		&mut self,
+		options: PtyOptions,
+	) -> io::Result<(Box<dyn ChildWrapper>, PtyController)> {
+		imp::spawn(self, options)
+	}
+
+	fn rebuild_command(&mut self) {
+		*self.command.command_mut() = self.intent.command();
+	}
+}
+
+/// The asynchronous input side of a pseudo-terminal.
+///
+/// Input and output are strong owners of the same bidirectional PTY master. Shutting down or
+/// dropping only this input object releases its owner but cannot close the master or produce child
+/// EOF while [`PtyOutput`] still exists. There is no independent transport half-close; send the
+/// terminal's VEOF control character when that is the desired terminal policy.
+#[derive(Debug)]
+pub struct PtyInput {
+	inner: imp::Input,
+}
+
+impl AsyncWrite for PtyInput {
+	fn poll_write(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buffer: &[u8],
+	) -> Poll<io::Result<usize>> {
+		Pin::new(&mut self.inner).poll_write(cx, buffer)
+	}
+
+	fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		Pin::new(&mut self.inner).poll_flush(cx)
+	}
+
+	fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		Pin::new(&mut self.inner).poll_shutdown(cx)
+	}
+}
+
+/// The asynchronous merged output side of a pseudo-terminal.
+///
+/// This is a strong owner of the shared bidirectional PTY master. Output EOF means that every slave
+/// descriptor has closed; it is independent from waiting for the direct child because a descendant
+/// may retain the slave after that child exits.
+#[derive(Debug)]
+pub struct PtyOutput {
+	inner: imp::Output,
+}
+
+impl AsyncRead for PtyOutput {
+	fn poll_read(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buffer: &mut ReadBuf<'_>,
+	) -> Poll<io::Result<()>> {
+		Pin::new(&mut self.inner).poll_read(cx, buffer)
+	}
+}
+
+/// A cloneable weak handle for resizing a pseudo-terminal.
+///
+/// Resize handles do not keep the PTY master alive.
+#[derive(Clone, Debug)]
+pub struct PtyResize {
+	inner: imp::Resize,
+}
+
+impl PtyResize {
+	/// Change the terminal size.
+	///
+	/// Returns [`io::ErrorKind::BrokenPipe`] after both strong I/O owners have been dropped.
+	pub fn resize(&self, size: PtySize) -> io::Result<()> {
+		size.validate()?;
+		self.inner.resize(size)
+	}
+}
+
+/// The I/O and resize controls for a spawned pseudo-terminal.
+///
+/// [`PtyInput`] and [`PtyOutput`] each strongly own one shared bidirectional master. The terminal
+/// hangs up only after both owners are gone; dropping either one alone is not a half-close. A
+/// [`PtyResize`] is weak and never keeps the terminal alive. There is deliberately no clonable
+/// force-close handle, parent-terminal raw mode, byte relay, key handling, VT parsing, scrollback,
+/// or pager policy in this transport.
+///
+/// Process supervision and PTY draining are separate lifecycles. Waiting for the direct child does
+/// not imply output EOF, because descendants can retain slave descriptors.
+#[derive(Debug)]
+pub struct PtyController {
+	input: PtyInput,
+	output: PtyOutput,
+	resize: PtyResize,
+}
+
+impl PtyController {
+	#[allow(dead_code)]
+	fn new(input: imp::Input, output: imp::Output, resize: imp::Resize) -> Self {
+		Self {
+			input: PtyInput { inner: input },
+			output: PtyOutput { inner: output },
+			resize: PtyResize { inner: resize },
+		}
+	}
+
+	/// Borrow the input side.
+	pub fn input(&mut self) -> &mut PtyInput {
+		&mut self.input
+	}
+
+	/// Borrow the merged output side.
+	pub fn output(&mut self) -> &mut PtyOutput {
+		&mut self.output
+	}
+
+	/// Clone the weak resize handle.
+	pub fn resizer(&self) -> PtyResize {
+		self.resize.clone()
+	}
+
+	/// Split the controller into independently owned input, output, and resize handles.
+	pub fn into_parts(self) -> (PtyInput, PtyOutput, PtyResize) {
+		(self.input, self.output, self.resize)
+	}
+}

--- a/src/tokio/pty.rs
+++ b/src/tokio/pty.rs
@@ -10,7 +10,13 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use super::{ChildWrapper, CommandWrap, CommandWrapper};
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+mod unix;
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 mod unsupported;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use unix as imp;
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 use unsupported as imp;
 
 /// The character and pixel dimensions of a pseudo-terminal.

--- a/src/tokio/pty.rs
+++ b/src/tokio/pty.rs
@@ -160,6 +160,10 @@ impl CommandWrapper for PtyMarker {}
 
 /// A tracked command builder for pseudo-terminal spawning.
 ///
+/// This API is available with the non-default `pty` crate feature. Linux and macOS provide a native
+/// backend; other targets compile the same API but [`spawn`](Self::spawn) returns
+/// [`io::ErrorKind::Unsupported`] without falling back to pipes.
+///
 /// The builder owns the complete portable command intent instead of exposing unrestricted mutable
 /// access to the underlying Tokio command. This lets platform backends preserve arguments,
 /// environment operations, the working directory, and wrapper registration exactly.
@@ -266,6 +270,11 @@ impl PtyCommand {
 	}
 
 	/// Register a process wrapper.
+	///
+	/// On the Unix PTY backend, `ProcessGroup::leader()` and `ProcessSession` each compose
+	/// individually and retain their group-aware child wrapper. `ProcessGroup::attach_to(...)` is
+	/// incompatible with a new PTY session, and explicitly registering both group and session
+	/// wrappers is ambiguous; spawning returns [`io::ErrorKind::InvalidInput`] in either case.
 	pub fn wrap<W: CommandWrapper + 'static>(&mut self, wrapper: W) -> &mut Self {
 		self.command.wrap(wrapper);
 		self
@@ -273,8 +282,14 @@ impl PtyCommand {
 
 	/// Spawn the command attached to a pseudo-terminal.
 	///
+	/// A bare Unix PTY creates the session, controlling terminal, and foreground process group needed
+	/// by the child. Standard output and standard error share the terminal and are returned as one
+	/// ordered byte stream through [`PtyOutput`].
+	///
 	/// This API never falls back to ordinary pipes. On a target without a backend it returns
-	/// [`io::ErrorKind::Unsupported`].
+	/// [`io::ErrorKind::Unsupported`], even when the supplied options would be invalid on a supported
+	/// target. Supported backends return [`io::ErrorKind::InvalidInput`] for zero character dimensions
+	/// or incompatible supervision wrappers.
 	pub fn spawn(
 		&mut self,
 		options: PtyOptions,

--- a/src/tokio/pty.rs
+++ b/src/tokio/pty.rs
@@ -10,13 +10,53 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use super::{ChildWrapper, CommandWrap, CommandWrapper};
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(
+	target_os = "android",
+	target_os = "dragonfly",
+	target_os = "freebsd",
+	target_os = "illumos",
+	target_os = "linux",
+	target_os = "macos",
+	target_os = "netbsd",
+	target_os = "openbsd",
+	target_os = "solaris"
+))]
 mod unix;
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(
+	target_os = "android",
+	target_os = "dragonfly",
+	target_os = "freebsd",
+	target_os = "illumos",
+	target_os = "linux",
+	target_os = "macos",
+	target_os = "netbsd",
+	target_os = "openbsd",
+	target_os = "solaris"
+)))]
 mod unsupported;
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(
+	target_os = "android",
+	target_os = "dragonfly",
+	target_os = "freebsd",
+	target_os = "illumos",
+	target_os = "linux",
+	target_os = "macos",
+	target_os = "netbsd",
+	target_os = "openbsd",
+	target_os = "solaris"
+))]
 use unix as imp;
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(
+	target_os = "android",
+	target_os = "dragonfly",
+	target_os = "freebsd",
+	target_os = "illumos",
+	target_os = "linux",
+	target_os = "macos",
+	target_os = "netbsd",
+	target_os = "openbsd",
+	target_os = "solaris"
+)))]
 use unsupported as imp;
 
 /// The character and pixel dimensions of a pseudo-terminal.
@@ -151,18 +191,20 @@ impl CommandIntent {
 	}
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(unix)]
 #[derive(Clone, Copy, Debug)]
 pub(super) struct PtyMarker;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(unix)]
 impl CommandWrapper for PtyMarker {}
 
 /// A tracked command builder for pseudo-terminal spawning.
 ///
-/// This API is available with the non-default `pty` crate feature. Linux and macOS provide a native
-/// backend; other targets compile the same API but [`spawn`](Self::spawn) returns
-/// [`io::ErrorKind::Unsupported`] without falling back to pipes.
+/// This API is available with the non-default `pty` crate feature. Linux, Android, macOS, the BSDs,
+/// illumos, and Solaris provide a native Unix backend; other targets compile the same API but
+/// [`spawn`](Self::spawn) returns [`io::ErrorKind::Unsupported`] without falling back to pipes.
+/// Linux and macOS run transport tests in CI; the other Unix backends are cross-compiled there
+/// pending native runners.
 ///
 /// The builder owns the complete portable command intent instead of exposing unrestricted mutable
 /// access to the underlying Tokio command. This lets platform backends preserve arguments,

--- a/src/tokio/pty/unix.rs
+++ b/src/tokio/pty/unix.rs
@@ -280,3 +280,83 @@ fn is_eof(_error: &io::Error) -> bool {
 fn closed() -> io::Error {
 	io::Error::new(io::ErrorKind::BrokenPipe, "the PTY master is closed")
 }
+
+#[cfg(test)]
+mod tests {
+	use std::{fs::File, os::fd::RawFd, sync::Mutex};
+
+	use nix::errno::Errno;
+
+	use super::*;
+
+	static DESCRIPTOR_TEST: Mutex<()> = Mutex::new(());
+
+	fn null_fd() -> OwnedFd {
+		File::open("/dev/null").unwrap().into()
+	}
+
+	fn assert_open(fd: RawFd) {
+		// SAFETY: the caller retains ownership of a descriptor which must still be open here.
+		assert_ne!(unsafe { libc::fcntl(fd, libc::F_GETFD) }, -1);
+	}
+
+	fn assert_closed(fd: RawFd) {
+		// SAFETY: fcntl reports EBADF without dereferencing or taking ownership of a closed descriptor.
+		assert_eq!(unsafe { libc::fcntl(fd, libc::F_GETFD) }, -1);
+		assert_eq!(Errno::last(), Errno::EBADF);
+	}
+
+	fn descriptors() -> (OwnedFd, OwnedFd, OwnedFd, [RawFd; 3]) {
+		let stdin = null_fd();
+		let stdout = null_fd();
+		let stderr = null_fd();
+		let raw = [stdin.as_raw_fd(), stdout.as_raw_fd(), stderr.as_raw_fd()];
+		(stdin, stdout, stderr, raw)
+	}
+
+	#[test]
+	fn winsize_preserves_character_and_pixel_dimensions() {
+		let native = winsize(PtySize {
+			rows: 31,
+			columns: 97,
+			pixel_width: 640,
+			pixel_height: 480,
+		});
+		assert_eq!(native.ws_row, 31);
+		assert_eq!(native.ws_col, 97);
+		assert_eq!(native.ws_xpixel, 640);
+		assert_eq!(native.ws_ypixel, 480);
+	}
+
+	#[test]
+	fn slave_stdio_is_dropped_when_the_spawn_operation_returns() {
+		let _lock = DESCRIPTOR_TEST.lock().unwrap();
+		let mut command = tokio::process::Command::new("ignored");
+		let (stdin, stdout, stderr, raw) = descriptors();
+
+		let result = with_slave_stdio(&mut command, stdin, stdout, stderr, |_| {
+			raw.into_iter().for_each(assert_open);
+			42
+		});
+
+		assert_eq!(result, 42);
+		raw.into_iter().for_each(assert_closed);
+	}
+
+	#[test]
+	fn slave_stdio_is_dropped_when_the_spawn_operation_panics() {
+		let _lock = DESCRIPTOR_TEST.lock().unwrap();
+		let mut command = tokio::process::Command::new("ignored");
+		let (stdin, stdout, stderr, raw) = descriptors();
+
+		let panic = catch_unwind(AssertUnwindSafe(|| {
+			with_slave_stdio(&mut command, stdin, stdout, stderr, |_| {
+				raw.into_iter().for_each(assert_open);
+				panic!("spawn operation panic");
+			});
+		}));
+
+		assert!(panic.is_err());
+		raw.into_iter().for_each(assert_closed);
+	}
+}

--- a/src/tokio/pty/unix.rs
+++ b/src/tokio/pty/unix.rs
@@ -4,7 +4,7 @@ use std::ffi::CStr;
 use std::path::Path;
 use std::{
 	io,
-	os::fd::{AsRawFd, FromRawFd, OwnedFd},
+	os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd},
 	panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
 	pin::Pin,
 	process::Stdio,
@@ -12,13 +12,6 @@ use std::{
 	task::{Context, Poll, ready},
 };
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
-use nix::pty::ptsname_r;
-use nix::{
-	fcntl::{FcntlArg, fcntl},
-	libc,
-	pty::Winsize,
-};
 #[cfg(any(
 	target_os = "dragonfly",
 	target_os = "freebsd",
@@ -27,15 +20,19 @@ use nix::{
 	target_os = "openbsd",
 	target_os = "solaris"
 ))]
-use nix::{
-	fcntl::{FdFlag, OFlag},
-	pty::openpty,
-};
+use nix::pty::openpty;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+use nix::pty::ptsname_r;
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 use nix::{
-	fcntl::{OFlag, open},
+	fcntl::open,
 	pty::{PtyMaster, grantpt, posix_openpt, unlockpt},
 	sys::stat::Mode,
+};
+use nix::{
+	fcntl::{FcntlArg, FdFlag, OFlag, fcntl},
+	libc,
+	pty::Winsize,
 };
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 use std::os::fd::IntoRawFd;
@@ -197,8 +194,9 @@ fn with_slave_stdio<T>(
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn open_pty(size: PtySize) -> io::Result<(OwnedFd, OwnedFd)> {
-	let master =
-		posix_openpt(OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_CLOEXEC | OFlag::O_NONBLOCK)?;
+	let master = posix_openpt(OFlag::O_RDWR | OFlag::O_NOCTTY)?;
+	set_close_on_exec(&master)?;
+	set_nonblocking(&master)?;
 	grantpt(&master)?;
 	unlockpt(&master)?;
 	let slave = open_slave(&master)?;
@@ -225,28 +223,12 @@ fn open_pty(size: PtySize) -> io::Result<(OwnedFd, OwnedFd)> {
 	Ok((pair.master, pair.slave))
 }
 
-#[cfg(any(
-	target_os = "dragonfly",
-	target_os = "freebsd",
-	target_os = "illumos",
-	target_os = "netbsd",
-	target_os = "openbsd",
-	target_os = "solaris"
-))]
-fn set_close_on_exec(fd: &OwnedFd) -> io::Result<()> {
+fn set_close_on_exec(fd: &impl AsFd) -> io::Result<()> {
 	fcntl(fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))?;
 	Ok(())
 }
 
-#[cfg(any(
-	target_os = "dragonfly",
-	target_os = "freebsd",
-	target_os = "illumos",
-	target_os = "netbsd",
-	target_os = "openbsd",
-	target_os = "solaris"
-))]
-fn set_nonblocking(fd: &OwnedFd) -> io::Result<()> {
+fn set_nonblocking(fd: &impl AsFd) -> io::Result<()> {
 	let flags = OFlag::from_bits_truncate(fcntl(fd, FcntlArg::F_GETFL)?);
 	fcntl(fd, FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK))?;
 	Ok(())
@@ -395,6 +377,19 @@ mod tests {
 		assert_eq!(native.ws_col, 97);
 		assert_eq!(native.ws_xpixel, 640);
 		assert_eq!(native.ws_ypixel, 480);
+	}
+
+	#[test]
+	fn allocated_master_has_close_on_exec_and_nonblocking() {
+		let (master, _slave) = open_pty(PtySize::default()).unwrap();
+		let descriptor_flags = FdFlag::from_bits_truncate(
+			fcntl(&master, FcntlArg::F_GETFD).expect("read descriptor flags"),
+		);
+		let status_flags = OFlag::from_bits_truncate(
+			fcntl(&master, FcntlArg::F_GETFL).expect("read status flags"),
+		);
+		assert!(descriptor_flags.contains(FdFlag::FD_CLOEXEC));
+		assert!(status_flags.contains(OFlag::O_NONBLOCK));
 	}
 
 	#[test]

--- a/src/tokio/pty/unix.rs
+++ b/src/tokio/pty/unix.rs
@@ -1,6 +1,6 @@
 #[cfg(target_os = "macos")]
 use std::ffi::CStr;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 use std::path::Path;
 use std::{
 	io,
@@ -12,19 +12,38 @@ use std::{
 	task::{Context, Poll, ready},
 };
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 use nix::pty::ptsname_r;
 use nix::{
-	fcntl::{FcntlArg, OFlag, fcntl, open},
+	fcntl::{FcntlArg, fcntl},
 	libc,
-	pty::{PtyMaster, Winsize, grantpt, posix_openpt, unlockpt},
+	pty::Winsize,
+};
+#[cfg(any(
+	target_os = "dragonfly",
+	target_os = "freebsd",
+	target_os = "illumos",
+	target_os = "netbsd",
+	target_os = "openbsd",
+	target_os = "solaris"
+))]
+use nix::{
+	fcntl::{FdFlag, OFlag},
+	pty::openpty,
+};
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+use nix::{
+	fcntl::{OFlag, open},
+	pty::{PtyMaster, grantpt, posix_openpt, unlockpt},
 	sys::stat::Mode,
 };
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+use std::os::fd::IntoRawFd;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf, unix::AsyncFd};
 
 use super::{ChildWrapper, PtyCommand, PtyController, PtyMarker, PtyOptions, PtySize};
 
-type Master = Arc<AsyncFd<PtyMaster>>;
+type Master = Arc<AsyncFd<OwnedFd>>;
 
 #[derive(Debug)]
 pub(super) struct Input {
@@ -98,7 +117,7 @@ impl AsyncRead for Output {
 
 #[derive(Clone, Debug)]
 pub(super) struct Resize {
-	master: Weak<AsyncFd<PtyMaster>>,
+	master: Weak<AsyncFd<OwnedFd>>,
 }
 
 impl Resize {
@@ -176,14 +195,61 @@ fn with_slave_stdio<T>(
 	}
 }
 
-fn open_pty(size: PtySize) -> io::Result<(PtyMaster, OwnedFd)> {
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn open_pty(size: PtySize) -> io::Result<(OwnedFd, OwnedFd)> {
 	let master =
 		posix_openpt(OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_CLOEXEC | OFlag::O_NONBLOCK)?;
 	grantpt(&master)?;
 	unlockpt(&master)?;
 	let slave = open_slave(&master)?;
+	// SAFETY: ownership moves from PtyMaster into exactly one OwnedFd.
+	let master = unsafe { OwnedFd::from_raw_fd(master.into_raw_fd()) };
 	set_size(&master, size)?;
 	Ok((master, slave))
+}
+
+#[cfg(any(
+	target_os = "dragonfly",
+	target_os = "freebsd",
+	target_os = "illumos",
+	target_os = "netbsd",
+	target_os = "openbsd",
+	target_os = "solaris"
+))]
+fn open_pty(size: PtySize) -> io::Result<(OwnedFd, OwnedFd)> {
+	let size = winsize(size);
+	let pair = openpty(Some(&size), None)?;
+	set_close_on_exec(&pair.master)?;
+	set_close_on_exec(&pair.slave)?;
+	set_nonblocking(&pair.master)?;
+	Ok((pair.master, pair.slave))
+}
+
+#[cfg(any(
+	target_os = "dragonfly",
+	target_os = "freebsd",
+	target_os = "illumos",
+	target_os = "netbsd",
+	target_os = "openbsd",
+	target_os = "solaris"
+))]
+fn set_close_on_exec(fd: &OwnedFd) -> io::Result<()> {
+	fcntl(fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))?;
+	Ok(())
+}
+
+#[cfg(any(
+	target_os = "dragonfly",
+	target_os = "freebsd",
+	target_os = "illumos",
+	target_os = "netbsd",
+	target_os = "openbsd",
+	target_os = "solaris"
+))]
+fn set_nonblocking(fd: &OwnedFd) -> io::Result<()> {
+	let flags = OFlag::from_bits_truncate(fcntl(fd, FcntlArg::F_GETFL)?);
+	fcntl(fd, FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK))?;
+	Ok(())
 }
 
 fn duplicate(fd: &OwnedFd) -> io::Result<OwnedFd> {
@@ -192,11 +258,12 @@ fn duplicate(fd: &OwnedFd) -> io::Result<OwnedFd> {
 	Ok(unsafe { OwnedFd::from_raw_fd(duplicated) })
 }
 
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn slave_flags() -> OFlag {
 	OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_CLOEXEC
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 fn open_slave(master: &PtyMaster) -> io::Result<OwnedFd> {
 	let name = ptsname_r(master)?;
 	open(Path::new(&name), slave_flags(), Mode::empty()).map_err(io::Error::from)
@@ -206,7 +273,14 @@ fn open_slave(master: &PtyMaster) -> io::Result<OwnedFd> {
 fn open_slave(master: &PtyMaster) -> io::Result<OwnedFd> {
 	let mut name = [0_u8; 128];
 	// SAFETY: name is the 128-byte output buffer encoded by Darwin's TIOCPTYGNAME request.
-	if unsafe { libc::ioctl(master.as_raw_fd(), libc::TIOCPTYGNAME, name.as_mut_ptr()) } == -1 {
+	if unsafe {
+		libc::ioctl(
+			master.as_raw_fd(),
+			libc::TIOCPTYGNAME.into(),
+			name.as_mut_ptr(),
+		)
+	} == -1
+	{
 		return Err(io::Error::last_os_error());
 	}
 	let name = CStr::from_bytes_until_nul(&name)
@@ -223,7 +297,7 @@ fn winsize(size: PtySize) -> Winsize {
 	}
 }
 
-fn set_size(master: &PtyMaster, size: PtySize) -> io::Result<()> {
+fn set_size(master: &OwnedFd, size: PtySize) -> io::Result<()> {
 	let size = winsize(size);
 	// SAFETY: master is a live PTY descriptor and size points to a valid winsize for the duration of
 	// the ioctl call.
@@ -240,7 +314,7 @@ fn setup_child() -> io::Result<()> {
 		if libc::setsid() == -1 {
 			return Err(io::Error::last_os_error());
 		}
-		if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY, 0) == -1 {
+		if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY as _, 0) == -1 {
 			return Err(io::Error::last_os_error());
 		}
 		if libc::tcsetpgrp(libc::STDIN_FILENO, libc::getpgrp()) == -1 {
@@ -250,7 +324,7 @@ fn setup_child() -> io::Result<()> {
 	Ok(())
 }
 
-fn read(fd: &PtyMaster, buffer: &mut [u8]) -> io::Result<usize> {
+fn read(fd: &OwnedFd, buffer: &mut [u8]) -> io::Result<usize> {
 	// SAFETY: the buffer is writable for its full length and remains live for the call.
 	let read = unsafe { libc::read(fd.as_raw_fd(), buffer.as_mut_ptr().cast(), buffer.len()) };
 	if read == -1 {
@@ -259,7 +333,7 @@ fn read(fd: &PtyMaster, buffer: &mut [u8]) -> io::Result<usize> {
 	Ok(read as usize)
 }
 
-fn write(fd: &PtyMaster, buffer: &[u8]) -> io::Result<usize> {
+fn write(fd: &OwnedFd, buffer: &[u8]) -> io::Result<usize> {
 	// SAFETY: the buffer is readable for its full length and remains live for the call.
 	let written = unsafe { libc::write(fd.as_raw_fd(), buffer.as_ptr().cast(), buffer.len()) };
 	if written == -1 {
@@ -268,14 +342,8 @@ fn write(fd: &PtyMaster, buffer: &[u8]) -> io::Result<usize> {
 	Ok(written as usize)
 }
 
-#[cfg(target_os = "linux")]
 fn is_eof(error: &io::Error) -> bool {
 	error.raw_os_error() == Some(libc::EIO)
-}
-
-#[cfg(target_os = "macos")]
-fn is_eof(_error: &io::Error) -> bool {
-	false
 }
 
 fn closed() -> io::Error {

--- a/src/tokio/pty/unix.rs
+++ b/src/tokio/pty/unix.rs
@@ -22,7 +22,7 @@ use nix::{
 };
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf, unix::AsyncFd};
 
-use super::{ChildWrapper, PtyCommand, PtyController, PtyOptions, PtySize};
+use super::{ChildWrapper, PtyCommand, PtyController, PtyMarker, PtyOptions, PtySize};
 
 type Master = Arc<AsyncFd<PtyMaster>>;
 
@@ -120,6 +120,7 @@ pub(super) fn spawn(
 
 	let master = Arc::new(AsyncFd::new(master)?);
 	command.rebuild_command();
+	command.command.wrap(PtyMarker);
 	let spawned = catch_unwind(AssertUnwindSafe(|| {
 		command.command.spawn_with(move |inner| {
 			with_slave_stdio(inner, slave_stdin, slave_stdout, slave, |inner| {

--- a/src/tokio/pty/unix.rs
+++ b/src/tokio/pty/unix.rs
@@ -334,16 +334,16 @@ fn closed() -> io::Error {
 
 #[cfg(test)]
 mod tests {
-	use std::{fs::File, os::fd::RawFd, sync::Mutex};
+	use std::os::fd::RawFd;
 
-	use nix::errno::Errno;
+	use nix::unistd::pipe;
 
 	use super::*;
 
-	static DESCRIPTOR_TEST: Mutex<()> = Mutex::new(());
-
-	fn null_fd() -> OwnedFd {
-		File::open("/dev/null").unwrap().into()
+	fn pipe_pair() -> (OwnedFd, OwnedFd) {
+		let (reader, writer) = pipe().unwrap();
+		set_nonblocking(&reader).unwrap();
+		(reader, writer)
 	}
 
 	fn assert_open(fd: RawFd) {
@@ -351,18 +351,31 @@ mod tests {
 		assert_ne!(unsafe { libc::fcntl(fd, libc::F_GETFD) }, -1);
 	}
 
-	fn assert_closed(fd: RawFd) {
-		// SAFETY: fcntl reports EBADF without dereferencing or taking ownership of a closed descriptor.
-		assert_eq!(unsafe { libc::fcntl(fd, libc::F_GETFD) }, -1);
-		assert_eq!(Errno::last(), Errno::EBADF);
+	fn assert_closed(reader: &OwnedFd) {
+		let mut byte = 0_u8;
+		// SAFETY: reader is a live nonblocking pipe descriptor and byte is writable for one byte.
+		let read =
+			unsafe { libc::read(reader.as_raw_fd(), std::ptr::from_mut(&mut byte).cast(), 1) };
+		if read != 0 {
+			panic!(
+				"pipe reader did not observe writer closure: {}",
+				io::Error::last_os_error()
+			);
+		}
 	}
 
-	fn descriptors() -> (OwnedFd, OwnedFd, OwnedFd, [RawFd; 3]) {
-		let stdin = null_fd();
-		let stdout = null_fd();
-		let stderr = null_fd();
+	fn descriptors() -> (OwnedFd, OwnedFd, OwnedFd, [OwnedFd; 3], [RawFd; 3]) {
+		let (stdin_reader, stdin) = pipe_pair();
+		let (stdout_reader, stdout) = pipe_pair();
+		let (stderr_reader, stderr) = pipe_pair();
 		let raw = [stdin.as_raw_fd(), stdout.as_raw_fd(), stderr.as_raw_fd()];
-		(stdin, stdout, stderr, raw)
+		(
+			stdin,
+			stdout,
+			stderr,
+			[stdin_reader, stdout_reader, stderr_reader],
+			raw,
+		)
 	}
 
 	#[test]
@@ -394,9 +407,8 @@ mod tests {
 
 	#[test]
 	fn slave_stdio_is_dropped_when_the_spawn_operation_returns() {
-		let _lock = DESCRIPTOR_TEST.lock().unwrap();
 		let mut command = tokio::process::Command::new("ignored");
-		let (stdin, stdout, stderr, raw) = descriptors();
+		let (stdin, stdout, stderr, readers, raw) = descriptors();
 
 		let result = with_slave_stdio(&mut command, stdin, stdout, stderr, |_| {
 			raw.into_iter().for_each(assert_open);
@@ -404,14 +416,13 @@ mod tests {
 		});
 
 		assert_eq!(result, 42);
-		raw.into_iter().for_each(assert_closed);
+		readers.iter().for_each(assert_closed);
 	}
 
 	#[test]
 	fn slave_stdio_is_dropped_when_the_spawn_operation_panics() {
-		let _lock = DESCRIPTOR_TEST.lock().unwrap();
 		let mut command = tokio::process::Command::new("ignored");
-		let (stdin, stdout, stderr, raw) = descriptors();
+		let (stdin, stdout, stderr, readers, raw) = descriptors();
 
 		let panic = catch_unwind(AssertUnwindSafe(|| {
 			with_slave_stdio(&mut command, stdin, stdout, stderr, |_| {
@@ -421,6 +432,6 @@ mod tests {
 		}));
 
 		assert!(panic.is_err());
-		raw.into_iter().for_each(assert_closed);
+		readers.iter().for_each(assert_closed);
 	}
 }

--- a/src/tokio/pty/unix.rs
+++ b/src/tokio/pty/unix.rs
@@ -1,0 +1,282 @@
+#[cfg(target_os = "macos")]
+use std::ffi::CStr;
+#[cfg(target_os = "linux")]
+use std::path::Path;
+use std::{
+	io,
+	os::fd::{AsRawFd, FromRawFd, OwnedFd},
+	panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
+	pin::Pin,
+	process::Stdio,
+	sync::{Arc, Weak},
+	task::{Context, Poll, ready},
+};
+
+#[cfg(target_os = "linux")]
+use nix::pty::ptsname_r;
+use nix::{
+	fcntl::{FcntlArg, OFlag, fcntl, open},
+	libc,
+	pty::{PtyMaster, Winsize, grantpt, posix_openpt, unlockpt},
+	sys::stat::Mode,
+};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf, unix::AsyncFd};
+
+use super::{ChildWrapper, PtyCommand, PtyController, PtyOptions, PtySize};
+
+type Master = Arc<AsyncFd<PtyMaster>>;
+
+#[derive(Debug)]
+pub(super) struct Input {
+	master: Option<Master>,
+}
+
+impl AsyncWrite for Input {
+	fn poll_write(
+		self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buffer: &[u8],
+	) -> Poll<io::Result<usize>> {
+		if buffer.is_empty() {
+			return Poll::Ready(Ok(0));
+		}
+
+		let Some(master) = self.get_mut().master.as_ref() else {
+			return Poll::Ready(Err(closed()));
+		};
+
+		loop {
+			let mut ready = ready!(master.poll_write_ready(cx))?;
+			match ready.try_io(|master| write(master.get_ref(), buffer)) {
+				Ok(result) => return Poll::Ready(result),
+				Err(_would_block) => continue,
+			}
+		}
+	}
+
+	fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		Poll::Ready(Ok(()))
+	}
+
+	fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		self.get_mut().master.take();
+		Poll::Ready(Ok(()))
+	}
+}
+
+#[derive(Debug)]
+pub(super) struct Output {
+	master: Master,
+}
+
+impl AsyncRead for Output {
+	fn poll_read(
+		self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buffer: &mut ReadBuf<'_>,
+	) -> Poll<io::Result<()>> {
+		if buffer.remaining() == 0 {
+			return Poll::Ready(Ok(()));
+		}
+
+		loop {
+			let mut ready = ready!(self.master.poll_read_ready(cx))?;
+			let result =
+				ready.try_io(|master| read(master.get_ref(), buffer.initialize_unfilled()));
+			match result {
+				Ok(Ok(read)) => {
+					buffer.advance(read);
+					return Poll::Ready(Ok(()));
+				}
+				Ok(Err(error)) if is_eof(&error) => return Poll::Ready(Ok(())),
+				Ok(Err(error)) => return Poll::Ready(Err(error)),
+				Err(_would_block) => continue,
+			}
+		}
+	}
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Resize {
+	master: Weak<AsyncFd<PtyMaster>>,
+}
+
+impl Resize {
+	pub(super) fn resize(&self, size: PtySize) -> io::Result<()> {
+		let master = self.master.upgrade().ok_or_else(closed)?;
+		set_size(master.get_ref(), size)
+	}
+}
+
+pub(super) fn spawn(
+	command: &mut PtyCommand,
+	options: PtyOptions,
+) -> io::Result<(Box<dyn ChildWrapper>, PtyController)> {
+	options.size.validate()?;
+
+	let (master, slave) = open_pty(options.size)?;
+	let slave_stdin = duplicate(&slave)?;
+	let slave_stdout = duplicate(&slave)?;
+
+	let master = Arc::new(AsyncFd::new(master)?);
+	command.rebuild_command();
+	let spawned = catch_unwind(AssertUnwindSafe(|| {
+		command.command.spawn_with(move |inner| {
+			with_slave_stdio(inner, slave_stdin, slave_stdout, slave, |inner| {
+				// SAFETY: the callback only invokes async-signal-safe libc functions and reports the
+				// operating system's error without accessing shared process state.
+				unsafe {
+					inner.pre_exec(setup_child);
+				}
+				inner.spawn()
+			})
+		})
+	}));
+	command.rebuild_command();
+
+	let child = match spawned {
+		Ok(child) => child?,
+		Err(payload) => resume_unwind(payload),
+	};
+	let input = Input {
+		master: Some(Arc::clone(&master)),
+	};
+	let resize = Resize {
+		master: Arc::downgrade(&master),
+	};
+	let output = Output { master };
+
+	Ok((child, PtyController::new(input, output, resize)))
+}
+
+fn with_slave_stdio<T>(
+	command: &mut tokio::process::Command,
+	stdin: OwnedFd,
+	stdout: OwnedFd,
+	stderr: OwnedFd,
+	operation: impl FnOnce(&mut tokio::process::Command) -> T,
+) -> T {
+	command
+		.stdin(Stdio::from(stdin))
+		.stdout(Stdio::from(stdout))
+		.stderr(Stdio::from(stderr));
+	let result = catch_unwind(AssertUnwindSafe(|| operation(command)));
+
+	// Drop every parent-side slave descriptor before spawn_with runs post-spawn or child-wrapping
+	// hooks. Stdio::null stores no open descriptor in the reusable command.
+	command
+		.stdin(Stdio::null())
+		.stdout(Stdio::null())
+		.stderr(Stdio::null());
+
+	match result {
+		Ok(result) => result,
+		Err(payload) => resume_unwind(payload),
+	}
+}
+
+fn open_pty(size: PtySize) -> io::Result<(PtyMaster, OwnedFd)> {
+	let master =
+		posix_openpt(OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_CLOEXEC | OFlag::O_NONBLOCK)?;
+	grantpt(&master)?;
+	unlockpt(&master)?;
+	let slave = open_slave(&master)?;
+	set_size(&master, size)?;
+	Ok((master, slave))
+}
+
+fn duplicate(fd: &OwnedFd) -> io::Result<OwnedFd> {
+	let duplicated = fcntl(fd, FcntlArg::F_DUPFD_CLOEXEC(0))?;
+	// SAFETY: F_DUPFD_CLOEXEC returned a new owned descriptor on success.
+	Ok(unsafe { OwnedFd::from_raw_fd(duplicated) })
+}
+
+fn slave_flags() -> OFlag {
+	OFlag::O_RDWR | OFlag::O_NOCTTY | OFlag::O_CLOEXEC
+}
+
+#[cfg(target_os = "linux")]
+fn open_slave(master: &PtyMaster) -> io::Result<OwnedFd> {
+	let name = ptsname_r(master)?;
+	open(Path::new(&name), slave_flags(), Mode::empty()).map_err(io::Error::from)
+}
+
+#[cfg(target_os = "macos")]
+fn open_slave(master: &PtyMaster) -> io::Result<OwnedFd> {
+	let mut name = [0_u8; 128];
+	// SAFETY: name is the 128-byte output buffer encoded by Darwin's TIOCPTYGNAME request.
+	if unsafe { libc::ioctl(master.as_raw_fd(), libc::TIOCPTYGNAME, name.as_mut_ptr()) } == -1 {
+		return Err(io::Error::last_os_error());
+	}
+	let name = CStr::from_bytes_until_nul(&name)
+		.map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+	open(name, slave_flags(), Mode::empty()).map_err(io::Error::from)
+}
+
+fn winsize(size: PtySize) -> Winsize {
+	Winsize {
+		ws_row: size.rows,
+		ws_col: size.columns,
+		ws_xpixel: size.pixel_width,
+		ws_ypixel: size.pixel_height,
+	}
+}
+
+fn set_size(master: &PtyMaster, size: PtySize) -> io::Result<()> {
+	let size = winsize(size);
+	// SAFETY: master is a live PTY descriptor and size points to a valid winsize for the duration of
+	// the ioctl call.
+	if unsafe { libc::ioctl(master.as_raw_fd(), libc::TIOCSWINSZ, &size) } == -1 {
+		return Err(io::Error::last_os_error());
+	}
+	Ok(())
+}
+
+fn setup_child() -> io::Result<()> {
+	// SAFETY: this function runs after fork and before exec. Each call is async-signal-safe and uses
+	// only the already-installed standard input descriptor.
+	unsafe {
+		if libc::setsid() == -1 {
+			return Err(io::Error::last_os_error());
+		}
+		if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY, 0) == -1 {
+			return Err(io::Error::last_os_error());
+		}
+		if libc::tcsetpgrp(libc::STDIN_FILENO, libc::getpgrp()) == -1 {
+			return Err(io::Error::last_os_error());
+		}
+	}
+	Ok(())
+}
+
+fn read(fd: &PtyMaster, buffer: &mut [u8]) -> io::Result<usize> {
+	// SAFETY: the buffer is writable for its full length and remains live for the call.
+	let read = unsafe { libc::read(fd.as_raw_fd(), buffer.as_mut_ptr().cast(), buffer.len()) };
+	if read == -1 {
+		return Err(io::Error::last_os_error());
+	}
+	Ok(read as usize)
+}
+
+fn write(fd: &PtyMaster, buffer: &[u8]) -> io::Result<usize> {
+	// SAFETY: the buffer is readable for its full length and remains live for the call.
+	let written = unsafe { libc::write(fd.as_raw_fd(), buffer.as_ptr().cast(), buffer.len()) };
+	if written == -1 {
+		return Err(io::Error::last_os_error());
+	}
+	Ok(written as usize)
+}
+
+#[cfg(target_os = "linux")]
+fn is_eof(error: &io::Error) -> bool {
+	error.raw_os_error() == Some(libc::EIO)
+}
+
+#[cfg(target_os = "macos")]
+fn is_eof(_error: &io::Error) -> bool {
+	false
+}
+
+fn closed() -> io::Error {
+	io::Error::new(io::ErrorKind::BrokenPipe, "the PTY master is closed")
+}

--- a/src/tokio/pty/unsupported.rs
+++ b/src/tokio/pty/unsupported.rs
@@ -1,0 +1,67 @@
+use std::{
+	io,
+	pin::Pin,
+	task::{Context, Poll},
+};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use super::{ChildWrapper, PtyCommand, PtyController, PtyOptions, PtySize};
+
+#[derive(Debug)]
+pub(super) struct Input;
+
+impl AsyncWrite for Input {
+	fn poll_write(
+		self: Pin<&mut Self>,
+		_cx: &mut Context<'_>,
+		_buffer: &[u8],
+	) -> Poll<io::Result<usize>> {
+		Poll::Ready(Err(unsupported()))
+	}
+
+	fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		Poll::Ready(Err(unsupported()))
+	}
+
+	fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		Poll::Ready(Err(unsupported()))
+	}
+}
+
+#[derive(Debug)]
+pub(super) struct Output;
+
+impl AsyncRead for Output {
+	fn poll_read(
+		self: Pin<&mut Self>,
+		_cx: &mut Context<'_>,
+		_buffer: &mut ReadBuf<'_>,
+	) -> Poll<io::Result<()>> {
+		Poll::Ready(Err(unsupported()))
+	}
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Resize;
+
+impl Resize {
+	pub(super) fn resize(&self, _size: PtySize) -> io::Result<()> {
+		Err(unsupported())
+	}
+}
+
+pub(super) fn spawn(
+	command: &mut PtyCommand,
+	_options: PtyOptions,
+) -> io::Result<(Box<dyn ChildWrapper>, PtyController)> {
+	command.rebuild_command();
+	Err(unsupported())
+}
+
+fn unsupported() -> io::Error {
+	io::Error::new(
+		io::ErrorKind::Unsupported,
+		"pseudo-terminal spawning is unsupported on this platform",
+	)
+}

--- a/src/tokio/reset_sigmask.rs
+++ b/src/tokio/reset_sigmask.rs
@@ -16,18 +16,13 @@ pub struct ResetSigmask;
 
 impl CommandWrapper for ResetSigmask {
 	fn pre_spawn(&mut self, command: &mut Command, _core: &CommandWrap) -> Result<()> {
+		#[cfg(feature = "tracing")]
+		trace!("registering child sigmask reset");
+
 		unsafe {
 			command.pre_exec(|| {
-				let mut oldset = SigSet::empty();
 				let newset = SigSet::all();
-
-				#[cfg(feature = "tracing")]
-				trace!(unblocking=?newset, "resetting process sigmask");
-
-				sigprocmask(SigmaskHow::SIG_UNBLOCK, Some(&newset), Some(&mut oldset))?;
-
-				#[cfg(feature = "tracing")]
-				trace!(?oldset, "sigmask reset");
+				sigprocmask(SigmaskHow::SIG_UNBLOCK, Some(&newset), None)?;
 				Ok(())
 			});
 		}

--- a/tests/tokio_pty_unix.rs
+++ b/tests/tokio_pty_unix.rs
@@ -1,4 +1,17 @@
-#![cfg(all(any(target_os = "linux", target_os = "macos"), feature = "pty"))]
+#![cfg(all(
+	feature = "pty",
+	any(
+		target_os = "android",
+		target_os = "dragonfly",
+		target_os = "freebsd",
+		target_os = "illumos",
+		target_os = "linux",
+		target_os = "macos",
+		target_os = "netbsd",
+		target_os = "openbsd",
+		target_os = "solaris"
+	)
+))]
 
 #[cfg(feature = "process-group")]
 use std::any::TypeId;
@@ -228,7 +241,7 @@ async fn direct_child_wait_is_independent_from_descendant_output_eof() -> io::Re
 	command
 		.args([
 			"-c",
-			"(trap '' HUP; printf ready; while [ ! -e \"$1\" ]; do sleep 1; done) &",
+			"trap '' HUP; (printf ready; while [ ! -e \"$1\" ]; do sleep 1; done) &",
 			"pty-test",
 		])
 		.arg(&release);

--- a/tests/tokio_pty_unix.rs
+++ b/tests/tokio_pty_unix.rs
@@ -484,13 +484,7 @@ async fn reset_sigmask_unblocks_signals_before_pty_setup() -> io::Result<()> {
 
 #[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
 fn pid_alive(pid: Pid) -> bool {
-	fn inner(pid: Pid) -> Result<bool, remoteprocess::Error> {
-		Ok(!remoteprocess::Process::new(pid.as_raw())?
-			.threads()?
-			.is_empty())
-	}
-
-	inner(pid).unwrap_or(false)
+	!matches!(kill(pid, None), Err(nix::errno::Errno::ESRCH))
 }
 
 #[cfg(all(feature = "kill-on-drop", feature = "process-session"))]

--- a/tests/tokio_pty_unix.rs
+++ b/tests/tokio_pty_unix.rs
@@ -17,7 +17,7 @@
 use std::any::TypeId;
 #[cfg(feature = "reset-sigmask")]
 use std::os::unix::process::ExitStatusExt;
-use std::{io, time::Duration};
+use std::{io, process::ExitStatus, time::Duration};
 
 #[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
 use nix::{
@@ -31,15 +31,28 @@ use process_wrap::tokio::KillOnDrop;
 use process_wrap::tokio::ProcessSession;
 #[cfg(feature = "reset-sigmask")]
 use process_wrap::tokio::ResetSigmask;
+use process_wrap::tokio::{ChildWrapper, PtyCommand, PtyOptions, PtyOutput, PtySize};
 #[cfg(feature = "process-group")]
 use process_wrap::tokio::{ProcessGroup, ProcessGroupChild};
-use process_wrap::tokio::{PtyCommand, PtyOptions, PtySize};
 #[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::{
 	io::{AsyncReadExt, AsyncWriteExt},
 	time::{sleep, timeout},
 };
+
+async fn wait_and_drain(
+	child: &mut dyn ChildWrapper,
+	output: &mut PtyOutput,
+) -> io::Result<(ExitStatus, Vec<u8>)> {
+	let mut bytes = Vec::new();
+	let status = timeout(Duration::from_secs(5), async {
+		let (status, _) = tokio::try_join!(child.wait(), output.read_to_end(&mut bytes))?;
+		Ok::<_, io::Error>(status)
+	})
+	.await??;
+	Ok((status, bytes))
+}
 
 #[tokio::test]
 async fn spawns_with_terminal_fds_and_merged_output() -> io::Result<()> {
@@ -52,11 +65,8 @@ async fn spawns_with_terminal_fds_and_merged_output() -> io::Result<()> {
 	let (mut child, controller) = command.spawn(PtyOptions::default())?;
 	let (input, mut output, _resize) = controller.into_parts();
 	drop(input);
-	let status = timeout(Duration::from_secs(5), child.wait()).await??;
+	let (status, bytes) = wait_and_drain(child.as_mut(), &mut output).await?;
 	assert!(status.success());
-
-	let mut bytes = Vec::new();
-	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
 	assert_eq!(bytes, b"stdin-ttystdout-ttystderr-ttystdoutstderr");
 	Ok(())
 }
@@ -110,14 +120,8 @@ async fn preserves_tracked_command_intent() -> io::Result<()> {
 	let (mut child, controller) = command.spawn(PtyOptions::default())?;
 	let (input, mut output, _resize) = controller.into_parts();
 	drop(input);
-	assert!(
-		timeout(Duration::from_secs(5), child.wait())
-			.await??
-			.success()
-	);
-
-	let mut bytes = Vec::new();
-	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	let (status, bytes) = wait_and_drain(child.as_mut(), &mut output).await?;
+	assert!(status.success());
 	assert_eq!(
 		String::from_utf8(bytes).unwrap(),
 		format!(
@@ -224,6 +228,7 @@ async fn dropping_output_does_not_hang_up_while_input_exists() -> io::Result<()>
 	Ok(())
 }
 
+#[cfg(not(target_os = "macos"))]
 #[tokio::test]
 async fn direct_child_wait_is_independent_from_descendant_output_eof() -> io::Result<()> {
 	struct ReleaseOnDrop(std::path::PathBuf);
@@ -281,13 +286,8 @@ async fn failed_spawn_leaves_command_reusable() -> io::Result<()> {
 	let (mut child, controller) = command.spawn(PtyOptions::default())?;
 	let (input, mut output, _resize) = controller.into_parts();
 	drop(input);
-	assert!(
-		timeout(Duration::from_secs(5), child.wait())
-			.await??
-			.success()
-	);
-	let mut bytes = Vec::new();
-	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	let (status, bytes) = wait_and_drain(child.as_mut(), &mut output).await?;
+	assert!(status.success());
 	assert_eq!(bytes, b"reused");
 	Ok(())
 }
@@ -390,13 +390,8 @@ async fn process_group_composes_when_registered_after_first_spawn() -> io::Resul
 	let (mut child, controller) = command.spawn(PtyOptions::default())?;
 	let (input, mut output, _resize) = controller.into_parts();
 	drop(input);
-	assert!(
-		timeout(Duration::from_secs(5), child.wait())
-			.await??
-			.success()
-	);
-	let mut bytes = Vec::new();
-	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	let (status, bytes) = wait_and_drain(child.as_mut(), &mut output).await?;
+	assert!(status.success());
 	assert_eq!(bytes, b"reused");
 
 	command.wrap(ProcessGroup::leader());
@@ -404,13 +399,8 @@ async fn process_group_composes_when_registered_after_first_spawn() -> io::Resul
 	assert_eq!(child.as_ref().type_id(), TypeId::of::<ProcessGroupChild>());
 	let (input, mut output, _resize) = controller.into_parts();
 	drop(input);
-	assert!(
-		timeout(Duration::from_secs(5), child.wait())
-			.await??
-			.success()
-	);
-	bytes.clear();
-	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	let (status, bytes) = wait_and_drain(child.as_mut(), &mut output).await?;
+	assert!(status.success());
 	assert_eq!(bytes, b"reused");
 	Ok(())
 }
@@ -515,14 +505,16 @@ impl Drop for KillPid {
 async fn kill_on_drop_remains_direct_child_only_with_a_pty_session() -> io::Result<()> {
 	let directory = tempfile::tempdir()?;
 	let ready = directory.path().join("descendant-ready");
+	let acknowledged = directory.path().join("descendant-acknowledged");
 	let mut command = PtyCommand::new("sh");
 	command
 		.args([
 			"-c",
-			r#"stty -echo; trap '' HUP; (trap '' HUP; trap 'printf "descendant-alive\n"; exit 0' USR1; : > "$1"; while :; do sleep 1; done) & printf '%s:%s\n' "$$" "$!"; wait"#,
+			r#"stty -echo; trap '' HUP; (trap '' HUP; trap ': > "$2"; exit 0' USR1; : > "$1"; while :; do sleep 1; done) & printf '%s:%s\n' "$$" "$!"; wait"#,
 			"pty-test",
 		])
 		.arg(&ready)
+		.arg(&acknowledged)
 		.wrap(ProcessSession)
 		.wrap(KillOnDrop);
 	let (child, controller) = command.spawn(PtyOptions::default())?;
@@ -557,11 +549,13 @@ async fn kill_on_drop_remains_direct_child_only_with_a_pty_session() -> io::Resu
 	direct_cleanup.disarm();
 
 	kill(descendant, Signal::SIGUSR1)?;
-	line.clear();
-	timeout(Duration::from_secs(5), output.read_line(&mut line)).await??;
-	assert_eq!(line.trim(), "descendant-alive");
-	let mut bytes = Vec::new();
-	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	timeout(Duration::from_secs(5), async {
+		while !acknowledged.exists() {
+			sleep(Duration::from_millis(10)).await;
+		}
+	})
+	.await
+	.expect("descendant did not acknowledge its signal");
 	timeout(Duration::from_secs(5), async {
 		while pid_alive(descendant) {
 			sleep(Duration::from_millis(10)).await;

--- a/tests/tokio_pty_unix.rs
+++ b/tests/tokio_pty_unix.rs
@@ -102,6 +102,7 @@ async fn passes_bidirectional_control_bytes_unchanged() -> io::Result<()> {
 #[tokio::test]
 async fn preserves_tracked_command_intent() -> io::Result<()> {
 	let directory = tempfile::tempdir()?;
+	let expected_directory = directory.path().canonicalize()?;
 	let mut command = PtyCommand::new("/bin/sh");
 	command
 		.args([
@@ -126,7 +127,7 @@ async fn preserves_tracked_command_intent() -> io::Result<()> {
 		String::from_utf8(bytes).unwrap(),
 		format!(
 			"argument|environment|unset|unset|{}",
-			directory.path().display()
+			expected_directory.display()
 		)
 	);
 	Ok(())

--- a/tests/tokio_pty_unix.rs
+++ b/tests/tokio_pty_unix.rs
@@ -1,0 +1,287 @@
+#![cfg(all(any(target_os = "linux", target_os = "macos"), feature = "pty"))]
+
+use std::{io, time::Duration};
+
+use process_wrap::tokio::{PtyCommand, PtyOptions, PtySize};
+use tokio::{
+	io::{AsyncReadExt, AsyncWriteExt},
+	time::{sleep, timeout},
+};
+
+#[tokio::test]
+async fn spawns_with_terminal_fds_and_merged_output() -> io::Result<()> {
+	let mut command = PtyCommand::new("sh");
+	command.args([
+		"-c",
+		"test -t 0 && printf stdin-tty; test -t 1 && printf stdout-tty; test -t 2 && printf stderr-tty >&2; printf stdout; printf stderr >&2",
+	]);
+
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	let status = timeout(Duration::from_secs(5), child.wait()).await??;
+	assert!(status.success());
+
+	let mut bytes = Vec::new();
+	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	assert_eq!(bytes, b"stdin-ttystdout-ttystderr-ttystdoutstderr");
+	Ok(())
+}
+
+#[tokio::test]
+async fn passes_bidirectional_control_bytes_unchanged() -> io::Result<()> {
+	let mut command = PtyCommand::new("sh");
+	command.args([
+		"-c",
+		"stty raw -echo; printf ready; dd bs=1 count=4 2>/dev/null",
+	]);
+
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (mut input, mut output, _resize) = controller.into_parts();
+	let mut ready = [0; 5];
+	timeout(Duration::from_secs(5), output.read_exact(&mut ready)).await??;
+	assert_eq!(&ready, b"ready");
+
+	let controls = [0x00, 0x1b, 0x03, 0xff];
+	input.write_all(&controls).await?;
+	let mut returned = [0; 4];
+	timeout(Duration::from_secs(5), output.read_exact(&mut returned)).await??;
+	assert_eq!(returned, controls);
+	input.shutdown().await?;
+	assert!(
+		timeout(Duration::from_secs(5), child.wait())
+			.await??
+			.success()
+	);
+	Ok(())
+}
+
+#[tokio::test]
+async fn preserves_tracked_command_intent() -> io::Result<()> {
+	let directory = tempfile::tempdir()?;
+	let mut command = PtyCommand::new("/bin/sh");
+	command
+		.args([
+			"-c",
+			"printf '%s|%s|%s|%s|%s' \"$1\" \"$VALUE\" \"${BEFORE-unset}\" \"${REMOVE-unset}\" \"$PWD\"",
+			"pty-test",
+			"argument",
+		])
+		.env("BEFORE", "discarded")
+		.env_clear()
+		.env("VALUE", "environment")
+		.env("REMOVE", "discarded")
+		.env_remove("REMOVE")
+		.current_dir(directory.path());
+
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	assert!(
+		timeout(Duration::from_secs(5), child.wait())
+			.await??
+			.success()
+	);
+
+	let mut bytes = Vec::new();
+	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	assert_eq!(
+		String::from_utf8(bytes).unwrap(),
+		format!(
+			"argument|environment|unset|unset|{}",
+			directory.path().display()
+		)
+	);
+	Ok(())
+}
+
+#[tokio::test]
+async fn reports_initial_size_and_sigwinch_resize() -> io::Result<()> {
+	let initial = PtySize::new(31, 97)?.with_pixels(640, 480);
+	let mut command = PtyCommand::new("sh");
+	command.args([
+		"-c",
+		"stty -echo; stty size; trap 'stty size; exit 0' WINCH; printf ready; while :; do sleep 1; done",
+	]);
+
+	let (mut child, controller) = command.spawn(PtyOptions::new(initial))?;
+	let (input, mut output, resize) = controller.into_parts();
+	let mut initial_output = [0; 12];
+	timeout(
+		Duration::from_secs(5),
+		output.read_exact(&mut initial_output),
+	)
+	.await??;
+	assert_eq!(&initial_output, b"31 97\r\nready");
+
+	assert_eq!(
+		resize
+			.resize(PtySize {
+				rows: 0,
+				columns: 113,
+				pixel_width: 0,
+				pixel_height: 0,
+			})
+			.unwrap_err()
+			.kind(),
+		io::ErrorKind::InvalidInput
+	);
+	resize.resize(PtySize::new(42, 113)?)?;
+	let mut resized = Vec::new();
+	timeout(Duration::from_secs(5), output.read_to_end(&mut resized)).await??;
+	assert_eq!(resized, b"42 113\r\n");
+	assert!(
+		timeout(Duration::from_secs(5), child.wait())
+			.await??
+			.success()
+	);
+	drop(input);
+	Ok(())
+}
+
+#[tokio::test]
+async fn shutting_down_input_does_not_hang_up_while_output_exists() -> io::Result<()> {
+	let mut command = PtyCommand::new("sh");
+	command.args(["-c", "stty -echo; printf ready; IFS= read -r line"]);
+
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (mut input, mut output, resize) = controller.into_parts();
+	let mut ready = [0; 5];
+	timeout(Duration::from_secs(5), output.read_exact(&mut ready)).await??;
+	assert_eq!(&ready, b"ready");
+
+	input.shutdown().await?;
+	assert_eq!(
+		input.write_all(b"closed").await.unwrap_err().kind(),
+		io::ErrorKind::BrokenPipe
+	);
+	sleep(Duration::from_millis(50)).await;
+	assert!(child.try_wait()?.is_none());
+	resize.resize(PtySize::default())?;
+
+	drop(output);
+	assert_eq!(
+		resize.resize(PtySize::default()).unwrap_err().kind(),
+		io::ErrorKind::BrokenPipe
+	);
+	timeout(Duration::from_secs(5), child.wait()).await??;
+	Ok(())
+}
+
+#[tokio::test]
+async fn dropping_output_does_not_hang_up_while_input_exists() -> io::Result<()> {
+	let mut command = PtyCommand::new("sh");
+	command.args(["-c", "stty -echo; printf ready; IFS= read -r line"]);
+
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, resize) = controller.into_parts();
+	let mut ready = [0; 5];
+	timeout(Duration::from_secs(5), output.read_exact(&mut ready)).await??;
+	drop(output);
+
+	sleep(Duration::from_millis(50)).await;
+	assert!(child.try_wait()?.is_none());
+	resize.resize(PtySize::default())?;
+	drop(input);
+	assert_eq!(
+		resize.resize(PtySize::default()).unwrap_err().kind(),
+		io::ErrorKind::BrokenPipe
+	);
+	timeout(Duration::from_secs(5), child.wait()).await??;
+	Ok(())
+}
+
+#[tokio::test]
+async fn direct_child_wait_is_independent_from_descendant_output_eof() -> io::Result<()> {
+	struct ReleaseOnDrop(std::path::PathBuf);
+
+	impl Drop for ReleaseOnDrop {
+		fn drop(&mut self) {
+			let _ = std::fs::File::create(&self.0);
+		}
+	}
+
+	let directory = tempfile::tempdir()?;
+	let release = directory.path().join("release-descendant");
+	let _release_on_drop = ReleaseOnDrop(release.clone());
+	let mut command = PtyCommand::new("sh");
+	command
+		.args([
+			"-c",
+			"(trap '' HUP; printf ready; while [ ! -e \"$1\" ]; do sleep 1; done) &",
+			"pty-test",
+		])
+		.arg(&release);
+
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	let mut ready = [0; 5];
+	timeout(Duration::from_secs(5), output.read_exact(&mut ready)).await??;
+	assert_eq!(&ready, b"ready");
+	assert!(
+		timeout(Duration::from_secs(5), child.wait())
+			.await??
+			.success()
+	);
+
+	let mut bytes = Vec::new();
+	assert!(
+		timeout(Duration::from_millis(100), output.read_to_end(&mut bytes))
+			.await
+			.is_err()
+	);
+	std::fs::File::create(&release)?;
+	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	Ok(())
+}
+
+#[tokio::test]
+async fn failed_spawn_leaves_command_reusable() -> io::Result<()> {
+	let mut command = PtyCommand::new("/process-wrap/definitely-does-not-exist");
+	assert_eq!(
+		command.spawn(PtyOptions::default()).unwrap_err().kind(),
+		io::ErrorKind::NotFound
+	);
+
+	command.program("sh").args(["-c", "printf reused"]);
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	assert!(
+		timeout(Duration::from_secs(5), child.wait())
+			.await??
+			.success()
+	);
+	let mut bytes = Vec::new();
+	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	assert_eq!(bytes, b"reused");
+	Ok(())
+}
+
+#[test]
+fn validates_character_dimensions() {
+	assert_eq!(
+		PtySize::new(0, 80).unwrap_err().kind(),
+		io::ErrorKind::InvalidInput
+	);
+	assert_eq!(
+		PtySize::new(24, 0).unwrap_err().kind(),
+		io::ErrorKind::InvalidInput
+	);
+}
+
+#[test]
+fn validates_spawn_options_before_opening_a_pty() {
+	let mut command = PtyCommand::new("ignored");
+	let options = PtyOptions::new(PtySize {
+		rows: 0,
+		columns: 80,
+		pixel_width: 0,
+		pixel_height: 0,
+	});
+	assert_eq!(
+		command.spawn(options).unwrap_err().kind(),
+		io::ErrorKind::InvalidInput
+	);
+}

--- a/tests/tokio_pty_unix.rs
+++ b/tests/tokio_pty_unix.rs
@@ -1,8 +1,28 @@
 #![cfg(all(any(target_os = "linux", target_os = "macos"), feature = "pty"))]
 
+#[cfg(feature = "process-group")]
+use std::any::TypeId;
+#[cfg(feature = "reset-sigmask")]
+use std::os::unix::process::ExitStatusExt;
 use std::{io, time::Duration};
 
+#[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
+use nix::{
+	sys::signal::{Signal, kill},
+	unistd::Pid,
+};
+
+#[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
+use process_wrap::tokio::KillOnDrop;
+#[cfg(feature = "process-session")]
+use process_wrap::tokio::ProcessSession;
+#[cfg(feature = "reset-sigmask")]
+use process_wrap::tokio::ResetSigmask;
+#[cfg(feature = "process-group")]
+use process_wrap::tokio::{ProcessGroup, ProcessGroupChild};
 use process_wrap::tokio::{PtyCommand, PtyOptions, PtySize};
+#[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::{
 	io::{AsyncReadExt, AsyncWriteExt},
 	time::{sleep, timeout},
@@ -256,6 +276,293 @@ async fn failed_spawn_leaves_command_reusable() -> io::Result<()> {
 	let mut bytes = Vec::new();
 	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
 	assert_eq!(bytes, b"reused");
+	Ok(())
+}
+
+#[tokio::test]
+async fn kill_and_start_kill_preserve_repeated_waits() -> io::Result<()> {
+	for wait_in_kill in [false, true] {
+		let mut command = PtyCommand::new("sh");
+		command.args(["-c", "stty -echo; printf ready; while :; do sleep 1; done"]);
+		let (mut child, controller) = command.spawn(PtyOptions::default())?;
+		let (input, mut output, _resize) = controller.into_parts();
+		let mut ready = [0; 5];
+		timeout(Duration::from_secs(5), output.read_exact(&mut ready)).await??;
+		assert_eq!(&ready, b"ready");
+		drop(input);
+
+		if wait_in_kill {
+			timeout(Duration::from_secs(5), Box::into_pin(child.kill())).await??;
+		} else {
+			child.start_kill()?;
+			timeout(Duration::from_secs(5), child.wait()).await??;
+		}
+		let status = child.try_wait()?.expect("killed child must have exited");
+		assert_eq!(child.try_wait()?, Some(status));
+		assert_eq!(child.wait().await?, status);
+		let mut bytes = Vec::new();
+		timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	}
+	Ok(())
+}
+
+#[cfg(feature = "process-group")]
+async fn assert_group_signal(mut command: PtyCommand) -> io::Result<()> {
+	command.args([
+		"-c",
+		"stty -echo; trap '' HUP; trap 'exit 0' TERM; sleep 30 & printf ready; wait",
+	]);
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	assert_eq!(child.as_ref().type_id(), TypeId::of::<ProcessGroupChild>());
+	assert!(child.try_wait()?.is_none());
+
+	let (input, mut output, _resize) = controller.into_parts();
+	let mut ready = [0; 5];
+	timeout(Duration::from_secs(5), output.read_exact(&mut ready)).await??;
+	assert_eq!(&ready, b"ready");
+	drop(input);
+
+	child.signal(nix::libc::SIGTERM)?;
+	let status = timeout(Duration::from_secs(5), child.wait()).await??;
+	assert_eq!(child.try_wait()?, Some(status));
+	assert_eq!(child.try_wait()?, Some(status));
+	assert_eq!(child.wait().await?, status);
+	let mut bytes = Vec::new();
+	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	Ok(())
+}
+
+#[cfg(feature = "process-group")]
+#[tokio::test]
+async fn process_group_leader_preserves_pty_group_supervision() -> io::Result<()> {
+	let mut command = PtyCommand::new("sh");
+	command.wrap(ProcessGroup::leader());
+	assert_group_signal(command).await
+}
+
+#[cfg(feature = "process-group")]
+#[tokio::test]
+async fn process_group_try_wait_keeps_native_child_synchronized() -> io::Result<()> {
+	let mut command = PtyCommand::new("sh");
+	command.args(["-c", "exit 17"]).wrap(ProcessGroup::leader());
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+
+	let status = timeout(Duration::from_secs(5), async {
+		loop {
+			if let Some(status) = child.try_wait()? {
+				break Ok::<_, io::Error>(status);
+			}
+			sleep(Duration::from_millis(10)).await;
+		}
+	})
+	.await??;
+	let native =
+		unsafe { child.try_inner_child_mut() }.expect("PTY group child must contain Tokio Child");
+	assert_eq!(native.try_wait()?, Some(status));
+	assert_eq!(child.try_wait()?, Some(status));
+	assert_eq!(child.wait().await?, status);
+	let mut bytes = Vec::new();
+	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	Ok(())
+}
+
+#[cfg(feature = "process-group")]
+#[tokio::test]
+async fn process_group_composes_when_registered_after_first_spawn() -> io::Result<()> {
+	let mut command = PtyCommand::new("sh");
+	command.args(["-c", "printf reused"]);
+
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	assert!(
+		timeout(Duration::from_secs(5), child.wait())
+			.await??
+			.success()
+	);
+	let mut bytes = Vec::new();
+	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	assert_eq!(bytes, b"reused");
+
+	command.wrap(ProcessGroup::leader());
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	assert_eq!(child.as_ref().type_id(), TypeId::of::<ProcessGroupChild>());
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	assert!(
+		timeout(Duration::from_secs(5), child.wait())
+			.await??
+			.success()
+	);
+	bytes.clear();
+	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	assert_eq!(bytes, b"reused");
+	Ok(())
+}
+
+#[cfg(feature = "process-session")]
+#[tokio::test]
+async fn process_session_preserves_pty_group_supervision() -> io::Result<()> {
+	let mut command = PtyCommand::new("sh");
+	command.wrap(ProcessSession);
+	assert_group_signal(command).await
+}
+
+#[cfg(feature = "process-group")]
+#[tokio::test]
+async fn rejects_attaching_a_pty_to_an_existing_group() {
+	for group in [ProcessGroup::attach_to(0), ProcessGroup::attach_to(42)] {
+		let mut command = PtyCommand::new("sh");
+		command.args(["-c", "exit 0"]).wrap(group);
+		assert_eq!(
+			command.spawn(PtyOptions::default()).unwrap_err().kind(),
+			io::ErrorKind::InvalidInput
+		);
+	}
+}
+
+#[cfg(feature = "process-session")]
+#[tokio::test]
+async fn rejects_explicit_group_and_session_in_either_order() {
+	for session_first in [false, true] {
+		let mut command = PtyCommand::new("sh");
+		command.args(["-c", "exit 0"]);
+		if session_first {
+			command.wrap(ProcessSession).wrap(ProcessGroup::leader());
+		} else {
+			command.wrap(ProcessGroup::leader()).wrap(ProcessSession);
+		}
+		assert_eq!(
+			command.spawn(PtyOptions::default()).unwrap_err().kind(),
+			io::ErrorKind::InvalidInput
+		);
+	}
+}
+
+#[cfg(feature = "reset-sigmask")]
+#[tokio::test]
+async fn reset_sigmask_unblocks_signals_before_pty_setup() -> io::Result<()> {
+	use nix::sys::signal::{SigSet, SigmaskHow, Signal, sigprocmask};
+
+	let mut blocked = SigSet::empty();
+	blocked.add(Signal::SIGUSR1);
+	let mut previous = SigSet::empty();
+	sigprocmask(SigmaskHow::SIG_BLOCK, Some(&blocked), Some(&mut previous))?;
+
+	let mut command = PtyCommand::new("sh");
+	command
+		.args(["-c", "test -t 0 || exit 2; kill -USR1 $$; printf survived"])
+		.wrap(ResetSigmask);
+	let spawned = command.spawn(PtyOptions::default());
+	sigprocmask(SigmaskHow::SIG_SETMASK, Some(&previous), None)?;
+	let (mut child, controller) = spawned?;
+
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	let status = timeout(Duration::from_secs(5), child.wait()).await??;
+	assert_eq!(status.signal(), Some(Signal::SIGUSR1 as i32));
+	let mut bytes = Vec::new();
+	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	assert!(bytes.is_empty());
+	Ok(())
+}
+
+#[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
+fn pid_alive(pid: Pid) -> bool {
+	fn inner(pid: Pid) -> Result<bool, remoteprocess::Error> {
+		Ok(!remoteprocess::Process::new(pid.as_raw())?
+			.threads()?
+			.is_empty())
+	}
+
+	inner(pid).unwrap_or(false)
+}
+
+#[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
+struct KillPid(Option<Pid>);
+
+#[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
+impl KillPid {
+	fn new(pid: Pid) -> Self {
+		Self(Some(pid))
+	}
+
+	fn disarm(&mut self) {
+		self.0 = None;
+	}
+}
+
+#[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
+impl Drop for KillPid {
+	fn drop(&mut self) {
+		if let Some(pid) = self.0 {
+			let _ = kill(pid, Signal::SIGKILL);
+		}
+	}
+}
+
+#[cfg(all(feature = "kill-on-drop", feature = "process-session"))]
+#[tokio::test]
+async fn kill_on_drop_remains_direct_child_only_with_a_pty_session() -> io::Result<()> {
+	let directory = tempfile::tempdir()?;
+	let ready = directory.path().join("descendant-ready");
+	let mut command = PtyCommand::new("sh");
+	command
+		.args([
+			"-c",
+			r#"stty -echo; trap '' HUP; (trap '' HUP; trap 'printf "descendant-alive\n"; exit 0' USR1; : > "$1"; while :; do sleep 1; done) & printf '%s:%s\n' "$$" "$!"; wait"#,
+			"pty-test",
+		])
+		.arg(&ready)
+		.wrap(ProcessSession)
+		.wrap(KillOnDrop);
+	let (child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, output, _resize) = controller.into_parts();
+	let mut output = BufReader::new(output);
+	let mut line = String::new();
+	timeout(Duration::from_secs(5), output.read_line(&mut line)).await??;
+	let (direct, descendant) = line.trim().split_once(':').unwrap();
+	let direct = Pid::from_raw(direct.parse().unwrap());
+	let descendant = Pid::from_raw(descendant.parse().unwrap());
+	assert_eq!(child.id(), Some(direct.as_raw() as u32));
+	let mut direct_cleanup = KillPid::new(direct);
+	let mut descendant_cleanup = KillPid::new(descendant);
+	assert!(pid_alive(direct));
+	timeout(Duration::from_secs(5), async {
+		while !ready.exists() {
+			sleep(Duration::from_millis(10)).await;
+		}
+	})
+	.await
+	.expect("descendant did not install its signal handler");
+
+	drop(input);
+	drop(child);
+	timeout(Duration::from_secs(5), async {
+		while pid_alive(direct) {
+			sleep(Duration::from_millis(10)).await;
+		}
+	})
+	.await
+	.expect("kill-on-drop did not terminate the direct child");
+	direct_cleanup.disarm();
+
+	kill(descendant, Signal::SIGUSR1)?;
+	line.clear();
+	timeout(Duration::from_secs(5), output.read_line(&mut line)).await??;
+	assert_eq!(line.trim(), "descendant-alive");
+	let mut bytes = Vec::new();
+	timeout(Duration::from_secs(5), output.read_to_end(&mut bytes)).await??;
+	timeout(Duration::from_secs(5), async {
+		while pid_alive(descendant) {
+			sleep(Duration::from_millis(10)).await;
+		}
+	})
+	.await
+	.expect("acknowledged descendant did not exit");
+	descendant_cleanup.disarm();
 	Ok(())
 }
 

--- a/tests/tokio_pty_unsupported.rs
+++ b/tests/tokio_pty_unsupported.rs
@@ -1,4 +1,17 @@
-#![cfg(all(feature = "pty", not(any(target_os = "linux", target_os = "macos"))))]
+#![cfg(all(
+	feature = "pty",
+	not(any(
+		target_os = "android",
+		target_os = "dragonfly",
+		target_os = "freebsd",
+		target_os = "illumos",
+		target_os = "linux",
+		target_os = "macos",
+		target_os = "netbsd",
+		target_os = "openbsd",
+		target_os = "solaris"
+	))
+))]
 
 use std::io;
 

--- a/tests/tokio_pty_unsupported.rs
+++ b/tests/tokio_pty_unsupported.rs
@@ -1,0 +1,29 @@
+#![cfg(all(feature = "pty", not(any(target_os = "linux", target_os = "macos"))))]
+
+use std::io;
+
+use process_wrap::tokio::{PtyCommand, PtyOptions, PtySize};
+
+#[test]
+fn spawning_is_explicitly_unsupported() {
+	let mut command = PtyCommand::new("ignored");
+	assert_eq!(
+		command.spawn(PtyOptions::default()).unwrap_err().kind(),
+		io::ErrorKind::Unsupported
+	);
+}
+
+#[test]
+fn unsupported_takes_precedence_over_size_validation() {
+	let mut command = PtyCommand::new("ignored");
+	let options = PtyOptions::new(PtySize {
+		rows: 0,
+		columns: 0,
+		pixel_width: 0,
+		pixel_height: 0,
+	});
+	assert_eq!(
+		command.spawn(options).unwrap_err().kind(),
+		io::ErrorKind::Unsupported
+	);
+}

--- a/tests/tokio_unix/mod.rs
+++ b/tests/tokio_unix/mod.rs
@@ -3,13 +3,24 @@ mod prelude {
 
 	pub use nix::sys::signal::Signal;
 	pub use process_wrap::tokio::*;
+	#[cfg(all(
+		target_os = "linux",
+		feature = "kill-on-drop",
+		any(feature = "process-group", feature = "process-session")
+	))]
+	pub use tokio::io::{AsyncBufReadExt, BufReader};
 	pub use tokio::{
-		io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader},
+		io::{AsyncReadExt, AsyncWriteExt},
 		time::sleep,
 	};
 
 	pub const DIE_TIME: Duration = Duration::from_millis(100);
 
+	#[cfg(all(
+		target_os = "linux",
+		feature = "kill-on-drop",
+		any(feature = "process-group", feature = "process-session")
+	))]
 	#[track_caller]
 	pub fn pid_alive(pid: i32) -> bool {
 		#[inline]
@@ -26,6 +37,11 @@ mod id_same_as_inner;
 mod inner_read_stdout;
 mod into_inner_write_stdin;
 mod kill_and_try_wait;
+#[cfg(all(
+	target_os = "linux",
+	feature = "kill-on-drop",
+	any(feature = "process-group", feature = "process-session")
+))]
 mod multiproc_linux;
 mod signals;
 mod try_wait_after_die;


### PR DESCRIPTION
Implement native PTY spawning on Unix with a controlling session and merged stdout/stderr.

- compose PTYs with process groups, sessions, reset-sigmask, and kill-on-drop while rejecting ambiguous combinations
- return `Unsupported` on targets without a backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
