### PR TITLE
feat: add Windows ConPTY support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - macos
-          - ubuntu
-          - windows
+        runner:
+          - macos-latest
+          - ubuntu-latest
+          - windows-2025
         toolchain:
           - stable
           - 1.87.0
@@ -26,8 +26,8 @@ jobs:
           - std
           - pty
 
-    name: "Test on ${{ matrix.platform }} with Rust ${{ matrix.toolchain }} (feat: ${{ matrix.features }})"
-    runs-on: "${{ matrix.platform }}-latest"
+    name: "Test on ${{ matrix.runner }} with Rust ${{ matrix.toolchain }} (feat: ${{ matrix.features }})"
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -72,13 +72,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - macos
-          - ubuntu
-          - windows
+        runner:
+          - macos-latest
+          - ubuntu-latest
+          - windows-2025
 
-    name: "Test all features on ${{ matrix.platform }}"
-    runs-on: "${{ matrix.platform }}-latest"
+    name: "Test all features on ${{ matrix.runner }}"
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -144,13 +144,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wrapper:
+        wrappers:
           - creation-flags
           - job-object
           - kill-on-drop
+          - "creation-flags,job-object"
+          - "job-object,kill-on-drop"
 
-    name: "Test Windows PTY with isolated ${{ matrix.wrapper }} wrapper"
-    runs-on: windows-latest
+    name: "Test Windows PTY wrappers (${{ matrix.wrappers }})"
+    runs-on: windows-2025
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -163,15 +165,15 @@ jobs:
           rustup default stable
           rustup component add clippy
 
-      - name: Test isolated wrapper
-        run: cargo test --locked --no-default-features --features "pty,${{ matrix.wrapper }}" --all-targets
+      - name: Test wrapper feature set
+        run: cargo test --locked --no-default-features --features "pty,${{ matrix.wrappers }}" --all-targets
 
-      - name: Lint isolated wrapper
-        run: cargo clippy --locked --no-default-features --features "pty,${{ matrix.wrapper }}" --all-targets -- -D warnings
+      - name: Lint wrapper feature set
+        run: cargo clippy --locked --no-default-features --features "pty,${{ matrix.wrappers }}" --all-targets -- -D warnings
 
   windows-conpty-imports:
     name: Check ConPTY dynamic imports
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -184,35 +186,46 @@ jobs:
           rustup default stable
           rustup component add llvm-tools-preview
 
-      - name: Build minimal PTY test artifact
+      - name: Build ConPTY integration test artifacts
         shell: pwsh
         run: |
-          $artifacts = cargo test --locked --no-default-features --features pty --lib --no-run --message-format=json |
-            ForEach-Object { $_ | ConvertFrom-Json } |
-            Where-Object { $_.reason -eq 'compiler-artifact' -and $_.target.name -eq 'process_wrap' -and $_.profile.test }
-          if ($LASTEXITCODE -ne 0) {
-            throw 'Cargo failed to build the process-wrap test executable'
+          function Build-ConPtyArtifact {
+            param([string[]] $FeatureArgs)
+            $artifacts = cargo test --locked @FeatureArgs --test tokio_pty_windows --no-run --message-format=json |
+              ForEach-Object { $_ | ConvertFrom-Json } |
+              Where-Object { $_.reason -eq 'compiler-artifact' -and $_.target.name -eq 'tokio_pty_windows' -and $_.profile.test }
+            if ($LASTEXITCODE -ne 0) {
+              throw "Cargo failed to build tokio_pty_windows with arguments: $FeatureArgs"
+            }
+            $executable = ($artifacts | Select-Object -Last 1).executable
+            if (-not $executable) {
+              throw 'Cargo did not report the tokio_pty_windows test executable'
+            }
+            return $executable
           }
-          $executable = ($artifacts | Select-Object -Last 1).executable
-          if (-not $executable) {
-            throw 'Cargo did not report the process-wrap test executable'
-          }
-          $executable | Set-Content "$env:RUNNER_TEMP\process-wrap-test-executable.txt"
+
+          $executables = @(
+            Build-ConPtyArtifact -FeatureArgs @('--no-default-features', '--features', 'pty')
+            Build-ConPtyArtifact -FeatureArgs @('--all-features')
+          )
+          $executables | Set-Content "$env:RUNNER_TEMP\process-wrap-conpty-test-executables.txt"
 
       - name: Reject static ConPTY imports
         shell: pwsh
         run: |
           $hostTriple = ((rustc -vV | Select-String '^host: ').Line -replace '^host: ', '')
           $readobj = Join-Path (rustc --print sysroot) "lib\rustlib\$hostTriple\bin\llvm-readobj.exe"
-          $executable = Get-Content "$env:RUNNER_TEMP\process-wrap-test-executable.txt"
-          $imports = & $readobj --coff-imports $executable
-          if ($LASTEXITCODE -ne 0) {
-            throw 'llvm-readobj failed to inspect the process-wrap test executable'
-          }
-          $forbidden = $imports | Select-String 'Symbol: (CreatePseudoConsole|ResizePseudoConsole|ReleasePseudoConsole|ClosePseudoConsole)'
-          if ($forbidden) {
-            $forbidden | Write-Error
-            throw 'ConPTY functions must be resolved dynamically'
+          $executables = Get-Content "$env:RUNNER_TEMP\process-wrap-conpty-test-executables.txt"
+          foreach ($executable in $executables) {
+            $imports = & $readobj --coff-imports $executable
+            if ($LASTEXITCODE -ne 0) {
+              throw "llvm-readobj failed to inspect $executable"
+            }
+            $forbidden = $imports | Select-String 'Symbol: (CreatePseudoConsole|ResizePseudoConsole|ReleasePseudoConsole|ClosePseudoConsole)'
+            if ($forbidden) {
+              $forbidden | Write-Error
+              throw "ConPTY functions in $executable must be resolved dynamically"
+            }
           }
 
   rustdoc:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw 'llvm-readobj failed to inspect the process-wrap test executable'
           }
-          $forbidden = $imports | Select-String 'Symbol: (CreatePseudoConsole|ResizePseudoConsole|ClosePseudoConsole)'
+          $forbidden = $imports | Select-String 'Symbol: (CreatePseudoConsole|ResizePseudoConsole|ReleasePseudoConsole|ClosePseudoConsole)'
           if ($forbidden) {
             $forbidden | Write-Error
             throw 'ConPTY functions must be resolved dynamically'
@@ -257,9 +257,18 @@ jobs:
           grep -Fx 'src/tokio/pty.rs' "$RUNNER_TEMP/package-files.txt"
           grep -Fx 'src/tokio/pty/unix.rs' "$RUNNER_TEMP/package-files.txt"
           grep -Fx 'src/tokio/pty/unsupported.rs' "$RUNNER_TEMP/package-files.txt"
-          grep -Fx 'src/tokio/pty/windows/mod.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/windows/api.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/windows/attributes.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/windows/backend.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/windows/child.rs' "$RUNNER_TEMP/package-files.txt"
           grep -Fx 'src/tokio/pty/windows/command.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/windows/console.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/windows/controller.rs' "$RUNNER_TEMP/package-files.txt"
           grep -Fx 'src/tokio/pty/windows/environment.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/windows/mod.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/windows/pipe.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/windows/program.rs' "$RUNNER_TEMP/package-files.txt"
+          grep -Fx 'src/tokio/pty/windows/spawn.rs' "$RUNNER_TEMP/package-files.txt"
 
   semver:
     name: Semver against PR base

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,6 +169,52 @@ jobs:
       - name: Lint isolated wrapper
         run: cargo clippy --locked --no-default-features --features "pty,${{ matrix.wrapper }}" --all-targets -- -D warnings
 
+  windows-conpty-imports:
+    name: Check ConPTY dynamic imports
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Configure Rust
+        run: |
+          rustup toolchain install --profile minimal --no-self-update stable
+          rustup default stable
+          rustup component add llvm-tools-preview
+
+      - name: Build minimal PTY test artifact
+        shell: pwsh
+        run: |
+          $artifacts = cargo test --locked --no-default-features --features pty --lib --no-run --message-format=json |
+            ForEach-Object { $_ | ConvertFrom-Json } |
+            Where-Object { $_.reason -eq 'compiler-artifact' -and $_.target.name -eq 'process_wrap' -and $_.profile.test }
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Cargo failed to build the process-wrap test executable'
+          }
+          $executable = ($artifacts | Select-Object -Last 1).executable
+          if (-not $executable) {
+            throw 'Cargo did not report the process-wrap test executable'
+          }
+          $executable | Set-Content "$env:RUNNER_TEMP\process-wrap-test-executable.txt"
+
+      - name: Reject static ConPTY imports
+        shell: pwsh
+        run: |
+          $hostTriple = ((rustc -vV | Select-String '^host: ').Line -replace '^host: ', '')
+          $readobj = Join-Path (rustc --print sysroot) "lib\rustlib\$hostTriple\bin\llvm-readobj.exe"
+          $executable = Get-Content "$env:RUNNER_TEMP\process-wrap-test-executable.txt"
+          $imports = & $readobj --coff-imports $executable
+          if ($LASTEXITCODE -ne 0) {
+            throw 'llvm-readobj failed to inspect the process-wrap test executable'
+          }
+          $forbidden = $imports | Select-String 'Symbol: (CreatePseudoConsole|ResizePseudoConsole|ClosePseudoConsole)'
+          if ($forbidden) {
+            $forbidden | Write-Error
+            throw 'ConPTY functions must be resolved dynamically'
+          }
+
   rustdoc:
     name: Rustdoc
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ std = ["dep:nix"]
 tokio1 = ["dep:nix", "dep:futures", "dep:tokio"]
 
 ## Tokio pseudo-terminal transport
-pty = ["tokio1", "nix/term", "tokio/net", "dep:windows", "windows/Win32_Globalization", "windows/Win32_System_Environment", "windows/Win32_System_Threading"]
+pty = ["tokio1", "nix/term", "tokio/net", "dep:windows", "windows/Win32_Globalization", "windows/Win32_System_Console", "windows/Win32_System_Environment", "windows/Win32_System_LibraryLoader", "windows/Win32_System_Threading"]
 
 ## Wrapper: Creation Flags
 creation-flags = ["dep:windows", "windows/Win32_System_Threading"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ std = ["dep:nix"]
 tokio1 = ["dep:nix", "dep:futures", "dep:tokio"]
 
 ## Tokio pseudo-terminal transport
-pty = ["tokio1", "nix/term", "tokio/net", "dep:windows", "windows/Win32_Globalization", "windows/Win32_System_Console", "windows/Win32_System_Environment", "windows/Win32_System_LibraryLoader", "windows/Win32_System_Threading"]
+pty = ["tokio1", "nix/term", "tokio/net", "dep:windows", "windows/Win32_Globalization", "windows/Win32_Security", "windows/Win32_Storage_FileSystem", "windows/Win32_System_Console", "windows/Win32_System_Environment", "windows/Win32_System_LibraryLoader", "windows/Win32_System_Pipes", "windows/Win32_System_Threading"]
 
 ## Wrapper: Creation Flags
 creation-flags = ["dep:windows", "windows/Win32_System_Threading"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ std = ["dep:nix"]
 tokio1 = ["dep:nix", "dep:futures", "dep:tokio"]
 
 ## Tokio pseudo-terminal transport
-pty = ["tokio1", "nix/term", "tokio/net", "dep:windows", "windows/Win32_Globalization", "windows/Win32_Security", "windows/Win32_Storage_FileSystem", "windows/Win32_System_Console", "windows/Win32_System_Environment", "windows/Win32_System_LibraryLoader", "windows/Win32_System_Pipes", "windows/Win32_System_Threading"]
+pty = ["tokio1", "nix/term", "tokio/net", "dep:windows", "windows/Win32_Globalization", "windows/Win32_Security", "windows/Win32_Storage_FileSystem", "windows/Win32_System_Console", "windows/Win32_System_Environment", "windows/Win32_System_LibraryLoader", "windows/Win32_System_Pipes", "windows/Win32_System_SystemInformation", "windows/Win32_System_Threading"]
 
 ## Wrapper: Creation Flags
 creation-flags = ["dep:windows", "windows/Win32_System_Threading"]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,10 @@ dbg!(status);
 ### or in a pseudo-terminal
 
 The non-default `pty` feature enables Tokio PTY transport on Linux, Android, macOS, FreeBSD,
-NetBSD, OpenBSD, DragonFly BSD, illumos, and Solaris. It implies `tokio1`. Other targets return
+NetBSD, OpenBSD, DragonFly BSD, illumos, and Solaris, plus ConPTY on Windows 11 24H2 (build
+26100), Windows Server 2025, and newer releases. It implies `tokio1`. The Windows backend
+dynamically resolves `CreatePseudoConsole`, `ResizePseudoConsole`, `ReleasePseudoConsole`, and
+`ClosePseudoConsole`; Windows versions without that complete capability set and other targets return
 `std::io::ErrorKind::Unsupported` rather than falling back to ordinary pipes. Linux and macOS run
 transport tests in CI; the other Unix backends are cross-compiled there pending native runners.
 
@@ -96,8 +99,7 @@ process-wrap = { version = "9.1.0", features = ["pty"] }
 use process_wrap::tokio::*;
 use tokio::io::AsyncReadExt;
 
-let mut command = PtyCommand::new("ls");
-command.wrap(ProcessSession);
+let mut command = PtyCommand::new("your-program");
 let (mut child, controller) = command.spawn(PtyOptions::default())?;
 let (input, mut output, _resize) = controller.into_parts();
 drop(input);
@@ -113,22 +115,33 @@ dbg!(status, terminal_bytes);
 ```
 
 A PTY intentionally merges stdout and stderr. `PtyInput` and `PtyOutput` are strong owners of one
-bidirectional master descriptor, so dropping either one alone does not half-close the terminal. The
-terminal hangs up after both are gone; `PtyResize` is weak and cannot keep it alive. Send the
-terminal's VEOF character when that is the desired terminal policy rather than expecting a separate
-input half-close or clonable force-close handle.
+terminal lifetime: on Unix they share a bidirectional master file description, while Windows uses
+independent host pipes and a shared pseudoconsole. Shutting down or dropping either owner alone does
+not hang up the terminal; `PtyResize` is weak and cannot keep it alive. There is no portable
+independent input half-close or clonable force-close promise. Send the terminal's VEOF character when
+that is the desired portable terminal policy.
 
-Child waiting and PTY draining are independent. On most supported Unix systems, descendants can retain
-the slave after the direct child exits. On macOS, drain output concurrently with waiting: the kernel
-drains queued output as the session leader exits, then revokes the controlling terminal from its
-descendants. The transport passes terminal bytes through without owning parent-terminal raw mode,
-relays, key handling, VT parsing, scrollback, or pager policy.
+Child waiting and PTY draining are independent. On most supported Unix systems, descendants can
+retain the slave after the direct child exits. On macOS, drain output concurrently with waiting: the
+kernel drains queued output as the session leader exits, then revokes the controlling terminal from
+its descendants. Windows descendants can remain attached to the pseudoconsole after the direct child
+exits; process-wrap releases application ownership after attachment, so output reaches EOF naturally
+once every client disconnects. Final pseudoconsole cleanup runs away from the Tokio reactor. The
+transport passes terminal bytes through without owning parent-terminal raw mode, relays, key handling,
+VT parsing, scrollback, or pager policy.
 
-A bare PTY creates the required session. `ProcessGroup::leader()` and `ProcessSession` each preserve
-their group-aware child supervision when used individually; `ProcessGroup::attach_to(...)` and
-explicitly registering both wrappers return `InvalidInput`. `ResetSigmask` composes normally.
-`KillOnDrop` remains Tokio's direct-child behavior—it does not promise to kill an entire group or
+A bare Unix PTY creates the required session. `ProcessGroup::leader()` and `ProcessSession` each
+preserve their group-aware child supervision when used individually; `ProcessGroup::attach_to(...)`
+and explicitly registering both wrappers return `InvalidInput`. `ResetSigmask` composes normally.
+`KillOnDrop` remains Tokio's direct-child behavior—it does not promise to kill an entire Unix group or
 session.
+
+The Windows backend accepts only the built-in `CreationFlags`, `JobObject`, and `KillOnDrop` wrappers
+whose features are enabled; another wrapper returns `InvalidInput` before spawn hooks run.
+`CreationFlags` and `JobObject` compose in either order, with temporary suspension used for job
+assignment and explicit `CREATE_SUSPENDED` preserved. `KillOnDrop` terminates the direct process when
+used alone and configures kill-on-job-close when combined with `JobObject`. Direct `.bat` and `.cmd`
+execution is rejected rather than choosing a command interpreter implicitly.
 
 ### or with std
 

--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ Child waiting and PTY draining are independent. On most supported Unix systems, 
 retain the slave after the direct child exits. On macOS, drain output concurrently with waiting: the
 kernel drains queued output as the session leader exits, then revokes the controlling terminal from
 its descendants. Windows descendants can remain attached to the pseudoconsole after the direct child
-exits; process-wrap releases application ownership when the direct child exits, so output then reaches
-EOF naturally once every client disconnects. Final pseudoconsole cleanup runs away from the Tokio
-reactor. The transport passes terminal bytes through without owning parent-terminal raw mode, relays,
-key handling, VT parsing, scrollback, or pager policy.
+exits; process-wrap releases ConPTY's startup reference after child setup, so output reaches EOF
+naturally once every client disconnects. Final pseudoconsole cleanup runs away from the Tokio reactor.
+The transport passes terminal bytes through without owning parent-terminal raw mode, relays, key
+handling, VT parsing, scrollback, or pager policy.
 
 A bare Unix PTY creates the required session. `ProcessGroup::leader()` and `ProcessSession` each
 preserve their group-aware child supervision when used individually; `ProcessGroup::attach_to(...)`

--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ Child waiting and PTY draining are independent. On most supported Unix systems, 
 retain the slave after the direct child exits. On macOS, drain output concurrently with waiting: the
 kernel drains queued output as the session leader exits, then revokes the controlling terminal from
 its descendants. Windows descendants can remain attached to the pseudoconsole after the direct child
-exits; process-wrap releases application ownership after attachment, so output reaches EOF naturally
-once every client disconnects. Final pseudoconsole cleanup runs away from the Tokio reactor. The
-transport passes terminal bytes through without owning parent-terminal raw mode, relays, key handling,
-VT parsing, scrollback, or pager policy.
+exits; process-wrap releases application ownership when the direct child exits, so output then reaches
+EOF naturally once every client disconnects. Final pseudoconsole cleanup runs away from the Tokio
+reactor. The transport passes terminal bytes through without owning parent-terminal raw mode, relays,
+key handling, VT parsing, scrollback, or pager policy.
 
 A bare Unix PTY creates the required session. `ProcessGroup::leader()` and `ProcessSession` each
 preserve their group-aware child supervision when used individually; `ProcessGroup::attach_to(...)`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,9 @@
 //! This crate provides a composable set of wrappers over `process::Command` (either from std or
 //! from Tokio). It is a more flexible and composable successor to the `command-group` crate. With
 //! the non-default `pty` feature, [`tokio::PtyCommand`] also spawns Tokio processes in native
-//! pseudo-terminals on Linux, Android, macOS, the BSDs, illumos, and Solaris while retaining the same
-//! child-wrapper and process group/session supervision APIs.
+//! pseudo-terminals on Linux, Android, macOS, the BSDs, illumos, and Solaris, or in ConPTY on
+//! Windows 11 24H2 (build 26100), Windows Server 2025, and newer releases, while retaining the
+//! supported child-wrapper and supervision APIs.
 //!
 //! # Usage
 //!
@@ -456,6 +457,7 @@
 //!
 //! - `std`: enables the std-based API.
 //! - `tokio1`: enables the Tokio-based API.
+//! - `pty`: enables Tokio PTY/ConPTY transport and implies `tokio1`.
 //!
 //! Both can exist at the same time, but generally you'll want to use one or the other.
 //!

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -27,7 +27,9 @@ pub use process_group::{ProcessGroup, ProcessGroupChild};
 pub use process_session::ProcessSession;
 #[cfg(feature = "pty")]
 #[doc(inline)]
-/// Pseudo-terminal support, available with the non-default `pty` crate feature.
+/// Native pseudo-terminal support on Linux and macOS and ConPTY support on Windows 11 24H2
+/// (build 26100), Windows Server 2025, and newer releases, available with the non-default `pty`
+/// crate feature.
 pub use pty::{PtyCommand, PtyController, PtyInput, PtyOptions, PtyOutput, PtyResize, PtySize};
 #[cfg(all(unix, feature = "reset-sigmask"))]
 #[doc(inline)]

--- a/src/tokio/core.rs
+++ b/src/tokio/core.rs
@@ -290,6 +290,11 @@ impl dyn ChildWrapper + '_ {
 		(self as &dyn Any).downcast_ref()
 	}
 
+	#[cfg(all(windows, feature = "pty", feature = "job-object"))]
+	pub(crate) fn downcast_mut<T: 'static>(&mut self) -> Option<&mut T> {
+		(self as &mut dyn Any).downcast_mut()
+	}
+
 	fn is_raw_child(&self) -> bool {
 		self.downcast_ref::<Child>().is_some()
 	}

--- a/src/tokio/job_object.rs
+++ b/src/tokio/job_object.rs
@@ -118,7 +118,12 @@ impl CommandWrapper for JobObject {
 		};
 
 		if policy.resume_after_assignment {
-			if let Err(error) = resume_threads(handle) {
+			#[cfg(feature = "pty")]
+			let resume_result = super::pty::try_resume_primary_thread(inner.as_mut())
+				.unwrap_or_else(|| resume_threads(handle));
+			#[cfg(not(feature = "pty"))]
+			let resume_result = resume_threads(handle);
+			if let Err(error) = resume_result {
 				let _ = terminate_job(job_port.job, 1);
 				terminate_child(&mut *inner);
 				return Err(error);

--- a/src/tokio/pty.rs
+++ b/src/tokio/pty.rs
@@ -25,6 +25,7 @@ use super::{ChildWrapper, CommandWrap, CommandWrapper};
 ))]
 mod unix;
 #[cfg(not(any(
+	windows,
 	target_os = "android",
 	target_os = "dragonfly",
 	target_os = "freebsd",
@@ -37,7 +38,6 @@ mod unix;
 )))]
 mod unsupported;
 #[cfg(windows)]
-#[allow(dead_code)]
 mod windows;
 #[cfg(any(
 	target_os = "android",
@@ -52,6 +52,7 @@ mod windows;
 ))]
 use unix as imp;
 #[cfg(not(any(
+	windows,
 	target_os = "android",
 	target_os = "dragonfly",
 	target_os = "freebsd",
@@ -63,6 +64,8 @@ use unix as imp;
 	target_os = "solaris"
 )))]
 use unsupported as imp;
+#[cfg(windows)]
+use windows as imp;
 
 /// The character and pixel dimensions of a pseudo-terminal.
 ///

--- a/src/tokio/pty.rs
+++ b/src/tokio/pty.rs
@@ -215,6 +215,11 @@ pub(super) struct PtyMarker;
 #[cfg(unix)]
 impl CommandWrapper for PtyMarker {}
 
+#[cfg(all(windows, feature = "job-object"))]
+pub(crate) fn try_resume_primary_thread(child: &mut dyn ChildWrapper) -> Option<io::Result<()>> {
+	windows::try_resume_primary_thread(child)
+}
+
 /// A tracked command builder for pseudo-terminal spawning.
 ///
 /// This API is available with the non-default `pty` crate feature. Linux, Android, macOS, the BSDs,

--- a/src/tokio/pty.rs
+++ b/src/tokio/pty.rs
@@ -69,9 +69,9 @@ use windows as imp;
 
 /// The character and pixel dimensions of a pseudo-terminal.
 ///
-/// Character dimensions must both be nonzero. Pixel dimensions may be zero when they are unknown or
-/// not meaningful to the caller. Sizes are validated by [`PtyCommand::spawn`] and
-/// [`PtyResize::resize`].
+/// Character dimensions must both be nonzero. Windows additionally limits both to 32767. Pixel
+/// dimensions may be zero when they are unknown or not meaningful to the caller, and ConPTY ignores
+/// them. Sizes are validated by [`PtyCommand::spawn`] and [`PtyResize::resize`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PtySize {
 	/// Character rows.
@@ -226,10 +226,11 @@ pub(crate) fn try_resume_primary_thread(child: &mut dyn ChildWrapper) -> Option<
 /// A tracked command builder for pseudo-terminal spawning.
 ///
 /// This API is available with the non-default `pty` crate feature. Linux, Android, macOS, the BSDs,
-/// illumos, and Solaris provide a native Unix backend; other targets compile the same API but
-/// [`spawn`](Self::spawn) returns [`io::ErrorKind::Unsupported`] without falling back to pipes.
-/// Linux and macOS run transport tests in CI; the other Unix backends are cross-compiled there
-/// pending native runners.
+/// illumos, and Solaris provide a native Unix backend. Windows uses ConPTY on Windows 11 24H2
+/// (build 26100), Windows Server 2025, and newer releases. Older Windows versions and other targets
+/// compile the same API but [`spawn`](Self::spawn) returns [`io::ErrorKind::Unsupported`] without
+/// falling back to pipes. Linux and macOS run transport tests in CI; the other Unix backends are
+/// cross-compiled there pending native runners.
 ///
 /// The builder owns the complete portable command intent instead of exposing unrestricted mutable
 /// access to the underlying Tokio command. This lets platform backends preserve arguments,
@@ -354,8 +355,12 @@ impl PtyCommand {
 	///
 	/// When Windows PTY spawning is supported, its backend accepts only the exact built-in
 	/// `CreationFlags`, `JobObject`, and `KillOnDrop` wrapper types whose crate features are enabled.
-	/// Any other command wrapper causes spawning to return [`io::ErrorKind::InvalidInput`] before
-	/// spawn-time hooks (`pre_spawn`, `post_spawn`, and `wrap_child`) run.
+	/// `CreationFlags` and `JobObject` compose in either registration order; job assignment uses
+	/// temporary suspension while preserving an explicitly requested `CREATE_SUSPENDED`.
+	/// `KillOnDrop` applies to the direct process alone or configures kill-on-job-close when combined
+	/// with `JobObject`. Any other command wrapper causes spawning to return
+	/// [`io::ErrorKind::InvalidInput`] before spawn-time hooks (`pre_spawn`, `post_spawn`, and
+	/// `wrap_child`) run.
 	pub fn wrap<W: CommandWrapper + 'static>(&mut self, wrapper: W) -> &mut Self {
 		#[cfg(windows)]
 		{
@@ -374,8 +379,14 @@ impl PtyCommand {
 	/// Spawn the command attached to a pseudo-terminal.
 	///
 	/// A bare Unix PTY creates the session, controlling terminal, and foreground process group needed
-	/// by the child. Standard output and standard error share the terminal and are returned as one
-	/// ordered byte stream through [`PtyOutput`].
+	/// by the child. Windows uses separate input and output pipes with ConPTY; child standard output
+	/// and standard error are merged on every supported backend and returned as one ordered byte stream
+	/// through [`PtyOutput`]. Direct Windows `.bat` and `.cmd` execution is rejected rather than
+	/// selecting a command interpreter implicitly.
+	///
+	/// The Windows backend dynamically resolves `CreatePseudoConsole`, `ResizePseudoConsole`,
+	/// `ReleasePseudoConsole`, and `ClosePseudoConsole`. Missing any capability returns
+	/// [`io::ErrorKind::Unsupported`] without preventing the crate itself from loading.
 	///
 	/// This API never falls back to ordinary pipes. On a target without a backend it returns
 	/// [`io::ErrorKind::Unsupported`], even when the supplied options would be invalid on a supported
@@ -395,10 +406,12 @@ impl PtyCommand {
 
 /// The asynchronous input side of a pseudo-terminal.
 ///
-/// Input and output are strong owners of the same bidirectional PTY master. Shutting down or
-/// dropping only this input object releases its owner but cannot close the master or produce child
-/// EOF while [`PtyOutput`] still exists. There is no independent transport half-close; send the
-/// terminal's VEOF control character when that is the desired terminal policy.
+/// Input and output are strong owners of the same terminal lifetime. On Unix they share one
+/// bidirectional PTY master file description; on Windows they use independent host pipes while
+/// sharing the pseudoconsole owner. Shutting down or dropping only this input object releases its
+/// owner but cannot by itself hang up the terminal while [`PtyOutput`] still exists. There is no
+/// portable independent transport half-close; send the terminal's VEOF control character when that
+/// is the desired portable terminal policy.
 #[derive(Debug)]
 pub struct PtyInput {
 	inner: imp::Input,
@@ -424,10 +437,12 @@ impl AsyncWrite for PtyInput {
 
 /// The asynchronous merged output side of a pseudo-terminal.
 ///
-/// This is a strong owner of the shared bidirectional PTY master. On most supported Unix systems,
-/// output EOF means that every slave descriptor has closed and a descendant may retain the slave
-/// after the direct child exits. On macOS, drain output concurrently with waiting: session-leader
-/// exit drains queued output and then revokes the controlling terminal from its descendants.
+/// This is a strong owner of the shared terminal. On most supported Unix systems, output EOF means
+/// that every slave descriptor has closed and a descendant may retain the slave after the direct
+/// child exits. On macOS, drain output concurrently with waiting: session-leader exit drains queued
+/// output and then revokes the controlling terminal from its descendants. On Windows, the
+/// pseudoconsole is released after process attachment and its output pipe closes once every attached
+/// client disconnects.
 #[derive(Debug)]
 pub struct PtyOutput {
 	inner: imp::Output,
@@ -445,7 +460,7 @@ impl AsyncRead for PtyOutput {
 
 /// A cloneable weak handle for resizing a pseudo-terminal.
 ///
-/// Resize handles do not keep the PTY master alive.
+/// Resize handles do not keep the terminal alive.
 #[derive(Clone, Debug)]
 pub struct PtyResize {
 	inner: imp::Resize,
@@ -463,16 +478,18 @@ impl PtyResize {
 
 /// The I/O and resize controls for a spawned pseudo-terminal.
 ///
-/// [`PtyInput`] and [`PtyOutput`] each strongly own one shared bidirectional master. The terminal
-/// hangs up only after both owners are gone; dropping either one alone is not a half-close. A
+/// [`PtyInput`] and [`PtyOutput`] each strongly own one shared terminal lifetime. On Unix this is a
+/// bidirectional master file description; on Windows it combines independent host pipes with the
+/// pseudoconsole. Parent-side ownership is fully released only after both owners are gone; dropping
+/// either one alone does not itself hang up the terminal and is not a portable half-close. A
 /// [`PtyResize`] is weak and never keeps the terminal alive. There is deliberately no clonable
-/// force-close handle, parent-terminal raw mode, byte relay, key handling, VT parsing, scrollback,
-/// or pager policy in this transport.
+/// force-close handle, parent-terminal raw mode, byte relay, key handling, VT parsing, scrollback, or
+/// pager policy in this transport.
 ///
 /// Process supervision and PTY draining are separate lifecycles. Waiting for the direct child does
-/// not imply output EOF on most supported Unix systems, because descendants can retain slave
-/// descriptors. On macOS, drive waiting and draining concurrently because session-leader exit waits
-/// for queued output before revoking the controlling terminal.
+/// not imply output EOF on most supported Unix systems or Windows, because descendants can retain
+/// their terminal connection. On macOS, drive waiting and draining concurrently because
+/// session-leader exit waits for queued output before revoking the controlling terminal.
 #[derive(Debug)]
 pub struct PtyController {
 	input: PtyInput,

--- a/src/tokio/pty.rs
+++ b/src/tokio/pty.rs
@@ -440,9 +440,9 @@ impl AsyncWrite for PtyInput {
 /// This is a strong owner of the shared terminal. On most supported Unix systems, output EOF means
 /// that every slave descriptor has closed and a descendant may retain the slave after the direct
 /// child exits. On macOS, drain output concurrently with waiting: session-leader exit drains queued
-/// output and then revokes the controlling terminal from its descendants. On Windows, application
-/// ownership of the pseudoconsole is released when the direct child exits, and its output pipe closes
-/// once every attached client disconnects.
+/// output and then revokes the controlling terminal from its descendants. On Windows, ConPTY's
+/// startup reference is released after child setup, and its output pipe closes once every attached
+/// client disconnects.
 #[derive(Debug)]
 pub struct PtyOutput {
 	inner: imp::Output,

--- a/src/tokio/pty.rs
+++ b/src/tokio/pty.rs
@@ -440,9 +440,9 @@ impl AsyncWrite for PtyInput {
 /// This is a strong owner of the shared terminal. On most supported Unix systems, output EOF means
 /// that every slave descriptor has closed and a descendant may retain the slave after the direct
 /// child exits. On macOS, drain output concurrently with waiting: session-leader exit drains queued
-/// output and then revokes the controlling terminal from its descendants. On Windows, the
-/// pseudoconsole is released after process attachment and its output pipe closes once every attached
-/// client disconnects.
+/// output and then revokes the controlling terminal from its descendants. On Windows, application
+/// ownership of the pseudoconsole is released when the direct child exits, and its output pipe closes
+/// once every attached client disconnects.
 #[derive(Debug)]
 pub struct PtyOutput {
 	inner: imp::Output,

--- a/src/tokio/pty/windows/api.rs
+++ b/src/tokio/pty/windows/api.rs
@@ -1,0 +1,68 @@
+//! Runtime resolution of the ConPTY API surface.
+//!
+//! These functions must not appear in the crate's static import table: loading process-wrap on an
+//! older Windows release must continue to work, with PTY spawning reporting `Unsupported` instead.
+
+use std::{ffi::CStr, io, sync::OnceLock};
+
+use windows::{
+	Win32::{
+		Foundation::{FARPROC, HANDLE},
+		System::{
+			Console::{COORD, HPCON},
+			LibraryLoader::{GetModuleHandleW, GetProcAddress},
+		},
+	},
+	core::{HRESULT, PCSTR, w},
+};
+
+pub(super) type CreatePseudoConsole =
+	unsafe extern "system" fn(COORD, HANDLE, HANDLE, u32, *mut HPCON) -> HRESULT;
+pub(super) type ResizePseudoConsole = unsafe extern "system" fn(HPCON, COORD) -> HRESULT;
+pub(super) type ClosePseudoConsole = unsafe extern "system" fn(HPCON);
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ConPtyApi {
+	pub(super) create: CreatePseudoConsole,
+	pub(super) resize: ResizePseudoConsole,
+	pub(super) close: ClosePseudoConsole,
+}
+
+pub(super) fn get() -> io::Result<&'static ConPtyApi> {
+	static API: OnceLock<Option<ConPtyApi>> = OnceLock::new();
+	API.get_or_init(resolve).as_ref().ok_or_else(|| {
+		io::Error::new(
+			io::ErrorKind::Unsupported,
+			"Windows pseudo-console APIs are unavailable",
+		)
+	})
+}
+
+fn resolve() -> Option<ConPtyApi> {
+	// SAFETY: kernel32.dll is loaded for every Windows process. GetModuleHandleW only borrows its
+	// module handle, and GetProcAddress returns addresses that remain valid for the process lifetime.
+	let kernel32 = unsafe { GetModuleHandleW(w!("kernel32.dll")) }.ok()?;
+	resolve_with(|name| unsafe { GetProcAddress(kernel32, PCSTR(name.as_ptr().cast())) })
+}
+
+fn resolve_with(mut lookup: impl FnMut(&CStr) -> FARPROC) -> Option<ConPtyApi> {
+	let create = lookup(c"CreatePseudoConsole")?;
+	let resize = lookup(c"ResizePseudoConsole")?;
+	let close = lookup(c"ClosePseudoConsole")?;
+
+	// SAFETY: each address was resolved under the matching exported function name. Win32 function
+	// pointers share one representation, and these signatures are the documented ConPTY ABI.
+	Some(unsafe {
+		ConPtyApi {
+			create: std::mem::transmute::<unsafe extern "system" fn() -> isize, CreatePseudoConsole>(
+				create,
+			),
+			resize: std::mem::transmute::<unsafe extern "system" fn() -> isize, ResizePseudoConsole>(
+				resize,
+			),
+			close: std::mem::transmute::<unsafe extern "system" fn() -> isize, ClosePseudoConsole>(
+				close,
+			),
+		}
+	})
+}

--- a/src/tokio/pty/windows/api.rs
+++ b/src/tokio/pty/windows/api.rs
@@ -19,12 +19,14 @@ use windows::{
 pub(super) type CreatePseudoConsole =
 	unsafe extern "system" fn(COORD, HANDLE, HANDLE, u32, *mut HPCON) -> HRESULT;
 pub(super) type ResizePseudoConsole = unsafe extern "system" fn(HPCON, COORD) -> HRESULT;
+pub(super) type ReleasePseudoConsole = unsafe extern "system" fn(HPCON) -> HRESULT;
 pub(super) type ClosePseudoConsole = unsafe extern "system" fn(HPCON);
 
 #[derive(Clone, Copy, Debug)]
 pub(super) struct ConPtyApi {
 	pub(super) create: CreatePseudoConsole,
 	pub(super) resize: ResizePseudoConsole,
+	pub(super) release: ReleasePseudoConsole,
 	pub(super) close: ClosePseudoConsole,
 }
 
@@ -48,6 +50,7 @@ fn resolve() -> Option<ConPtyApi> {
 fn resolve_with(mut lookup: impl FnMut(&CStr) -> FARPROC) -> Option<ConPtyApi> {
 	let create = lookup(c"CreatePseudoConsole")?;
 	let resize = lookup(c"ResizePseudoConsole")?;
+	let release = lookup(c"ReleasePseudoConsole")?;
 	let close = lookup(c"ClosePseudoConsole")?;
 
 	// SAFETY: each address was resolved under the matching exported function name. Win32 function
@@ -60,6 +63,10 @@ fn resolve_with(mut lookup: impl FnMut(&CStr) -> FARPROC) -> Option<ConPtyApi> {
 			resize: std::mem::transmute::<unsafe extern "system" fn() -> isize, ResizePseudoConsole>(
 				resize,
 			),
+			release: std::mem::transmute::<
+				unsafe extern "system" fn() -> isize,
+				ReleasePseudoConsole,
+			>(release),
 			close: std::mem::transmute::<unsafe extern "system" fn() -> isize, ClosePseudoConsole>(
 				close,
 			),
@@ -85,6 +92,10 @@ mod tests {
 		HRESULT(0)
 	}
 
+	unsafe extern "system" fn release(_pseudo_console: HPCON) -> HRESULT {
+		HRESULT(0)
+	}
+
 	unsafe extern "system" fn close(_pseudo_console: HPCON) {}
 
 	fn create_proc() -> FARPROC {
@@ -101,6 +112,15 @@ mod tests {
 		})
 	}
 
+	fn release_proc() -> FARPROC {
+		// SAFETY: tests erase this pointer only so resolve_with can restore its original signature.
+		Some(unsafe {
+			std::mem::transmute::<ReleasePseudoConsole, unsafe extern "system" fn() -> isize>(
+				release,
+			)
+		})
+	}
+
 	fn close_proc() -> FARPROC {
 		// SAFETY: tests erase this pointer only so resolve_with can restore its original signature.
 		Some(unsafe {
@@ -112,13 +132,14 @@ mod tests {
 		match name.to_bytes() {
 			b"CreatePseudoConsole" => create_proc(),
 			b"ResizePseudoConsole" => resize_proc(),
+			b"ReleasePseudoConsole" => release_proc(),
 			b"ClosePseudoConsole" => close_proc(),
 			_ => None,
 		}
 	}
 
 	#[test]
-	fn resolves_all_three_exports_by_exact_name() {
+	fn resolves_all_four_exports_by_exact_name() {
 		let mut requested = Vec::new();
 		let api = resolve_with(|name| {
 			requested.push(name.to_bytes().to_vec());
@@ -128,15 +149,18 @@ mod tests {
 
 		let expected_create: CreatePseudoConsole = create;
 		let expected_resize: ResizePseudoConsole = resize;
+		let expected_release: ReleasePseudoConsole = release;
 		let expected_close: ClosePseudoConsole = close;
 		assert_eq!(api.create as *const (), expected_create as *const ());
 		assert_eq!(api.resize as *const (), expected_resize as *const ());
+		assert_eq!(api.release as *const (), expected_release as *const ());
 		assert_eq!(api.close as *const (), expected_close as *const ());
 		assert_eq!(
 			requested,
 			[
 				b"CreatePseudoConsole".to_vec(),
 				b"ResizePseudoConsole".to_vec(),
+				b"ReleasePseudoConsole".to_vec(),
 				b"ClosePseudoConsole".to_vec(),
 			]
 		);
@@ -147,6 +171,7 @@ mod tests {
 		for missing in [
 			b"CreatePseudoConsole".as_slice(),
 			b"ResizePseudoConsole".as_slice(),
+			b"ReleasePseudoConsole".as_slice(),
 			b"ClosePseudoConsole".as_slice(),
 		] {
 			let api = resolve_with(|name| {

--- a/src/tokio/pty/windows/api.rs
+++ b/src/tokio/pty/windows/api.rs
@@ -66,3 +66,101 @@ fn resolve_with(mut lookup: impl FnMut(&CStr) -> FARPROC) -> Option<ConPtyApi> {
 		}
 	})
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	unsafe extern "system" fn create(
+		_size: COORD,
+		_input: HANDLE,
+		_output: HANDLE,
+		_flags: u32,
+		_pseudo_console: *mut HPCON,
+	) -> HRESULT {
+		HRESULT(0)
+	}
+
+	unsafe extern "system" fn resize(_pseudo_console: HPCON, _size: COORD) -> HRESULT {
+		HRESULT(0)
+	}
+
+	unsafe extern "system" fn close(_pseudo_console: HPCON) {}
+
+	fn create_proc() -> FARPROC {
+		// SAFETY: tests erase this pointer only so resolve_with can restore its original signature.
+		Some(unsafe {
+			std::mem::transmute::<CreatePseudoConsole, unsafe extern "system" fn() -> isize>(create)
+		})
+	}
+
+	fn resize_proc() -> FARPROC {
+		// SAFETY: tests erase this pointer only so resolve_with can restore its original signature.
+		Some(unsafe {
+			std::mem::transmute::<ResizePseudoConsole, unsafe extern "system" fn() -> isize>(resize)
+		})
+	}
+
+	fn close_proc() -> FARPROC {
+		// SAFETY: tests erase this pointer only so resolve_with can restore its original signature.
+		Some(unsafe {
+			std::mem::transmute::<ClosePseudoConsole, unsafe extern "system" fn() -> isize>(close)
+		})
+	}
+
+	fn lookup(name: &CStr) -> FARPROC {
+		match name.to_bytes() {
+			b"CreatePseudoConsole" => create_proc(),
+			b"ResizePseudoConsole" => resize_proc(),
+			b"ClosePseudoConsole" => close_proc(),
+			_ => None,
+		}
+	}
+
+	#[test]
+	fn resolves_all_three_exports_by_exact_name() {
+		let mut requested = Vec::new();
+		let api = resolve_with(|name| {
+			requested.push(name.to_bytes().to_vec());
+			lookup(name)
+		})
+		.unwrap();
+
+		let expected_create: CreatePseudoConsole = create;
+		let expected_resize: ResizePseudoConsole = resize;
+		let expected_close: ClosePseudoConsole = close;
+		assert_eq!(api.create as *const (), expected_create as *const ());
+		assert_eq!(api.resize as *const (), expected_resize as *const ());
+		assert_eq!(api.close as *const (), expected_close as *const ());
+		assert_eq!(
+			requested,
+			[
+				b"CreatePseudoConsole".to_vec(),
+				b"ResizePseudoConsole".to_vec(),
+				b"ClosePseudoConsole".to_vec(),
+			]
+		);
+	}
+
+	#[test]
+	fn rejects_an_incomplete_capability_set() {
+		for missing in [
+			b"CreatePseudoConsole".as_slice(),
+			b"ResizePseudoConsole".as_slice(),
+			b"ClosePseudoConsole".as_slice(),
+		] {
+			let api = resolve_with(|name| {
+				if name.to_bytes() == missing {
+					None
+				} else {
+					lookup(name)
+				}
+			});
+			assert!(
+				api.is_none(),
+				"missing {}",
+				String::from_utf8_lossy(missing)
+			);
+		}
+	}
+}

--- a/src/tokio/pty/windows/attributes.rs
+++ b/src/tokio/pty/windows/attributes.rs
@@ -68,3 +68,24 @@ impl Drop for AttributeList {
 		unsafe { DeleteProcThreadAttributeList(self.list) };
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use std::mem::align_of;
+
+	use super::*;
+
+	#[test]
+	fn allocates_an_aligned_single_pseudoconsole_attribute() {
+		let attributes = AttributeList::new(HPCON(42)).unwrap();
+		assert!(!attributes.as_ptr().is_invalid());
+		assert_eq!(
+			attributes.storage.as_ptr() as usize % align_of::<usize>(),
+			0
+		);
+		assert_eq!(
+			attributes.as_ptr().0,
+			attributes.storage.as_ptr().cast_mut().cast()
+		);
+	}
+}

--- a/src/tokio/pty/windows/attributes.rs
+++ b/src/tokio/pty/windows/attributes.rs
@@ -1,0 +1,70 @@
+//! Aligned ownership for a pseudo-console process-thread attribute list.
+
+use std::{ffi::c_void, io, mem::size_of};
+
+use windows::Win32::System::{
+	Console::HPCON,
+	Threading::{
+		DeleteProcThreadAttributeList, InitializeProcThreadAttributeList,
+		LPPROC_THREAD_ATTRIBUTE_LIST, PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+		UpdateProcThreadAttribute,
+	},
+};
+
+#[derive(Debug)]
+pub(super) struct AttributeList {
+	list: LPPROC_THREAD_ATTRIBUTE_LIST,
+	storage: Box<[usize]>,
+}
+
+impl AttributeList {
+	pub(super) fn new(pseudo_console: HPCON) -> io::Result<Self> {
+		let mut bytes = 0;
+		// SAFETY: a null first call is the documented size query and bytes is writable storage.
+		let _ = unsafe { InitializeProcThreadAttributeList(None, 1, None, &mut bytes) };
+		if bytes == 0 {
+			return Err(io::Error::last_os_error());
+		}
+
+		let words = bytes.div_ceil(size_of::<usize>());
+		let mut storage = vec![0usize; words].into_boxed_slice();
+		let list = LPPROC_THREAD_ATTRIBUTE_LIST(storage.as_mut_ptr().cast());
+		// SAFETY: storage is pointer-aligned, has at least the queried byte size, and remains owned by
+		// the returned guard until after DeleteProcThreadAttributeList runs.
+		unsafe { InitializeProcThreadAttributeList(Some(list), 1, None, &mut bytes) }
+			.map_err(io::Error::other)?;
+
+		// Microsoft documents passing the HPCON value itself as lpValue, rather than a pointer to a
+		// separate HPCON variable.
+		// SAFETY: list is initialized for one attribute and pseudo_console is a live handle whose owner
+		// outlives this list's use by CreateProcessW.
+		if let Err(error) = unsafe {
+			UpdateProcThreadAttribute(
+				list,
+				0,
+				PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE as usize,
+				Some(pseudo_console.0 as *const c_void),
+				size_of::<HPCON>(),
+				None,
+				None,
+			)
+		} {
+			// SAFETY: the list was initialized successfully and has not yet been deleted.
+			unsafe { DeleteProcThreadAttributeList(list) };
+			return Err(io::Error::other(error));
+		}
+
+		Ok(Self { list, storage })
+	}
+
+	pub(super) fn as_ptr(&self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+		self.list
+	}
+}
+
+impl Drop for AttributeList {
+	fn drop(&mut self) {
+		// SAFETY: this guard owns one initialized list and drops it before its aligned storage.
+		unsafe { DeleteProcThreadAttributeList(self.list) };
+	}
+}

--- a/src/tokio/pty/windows/attributes.rs
+++ b/src/tokio/pty/windows/attributes.rs
@@ -14,7 +14,7 @@ use windows::Win32::System::{
 #[derive(Debug)]
 pub(super) struct AttributeList {
 	list: LPPROC_THREAD_ATTRIBUTE_LIST,
-	storage: Box<[usize]>,
+	_storage: Box<[usize]>,
 }
 
 impl AttributeList {
@@ -54,7 +54,10 @@ impl AttributeList {
 			return Err(io::Error::other(error));
 		}
 
-		Ok(Self { list, storage })
+		Ok(Self {
+			list,
+			_storage: storage,
+		})
 	}
 
 	pub(super) fn as_ptr(&self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
@@ -80,12 +83,12 @@ mod tests {
 		let attributes = AttributeList::new(HPCON(42)).unwrap();
 		assert!(!attributes.as_ptr().is_invalid());
 		assert_eq!(
-			attributes.storage.as_ptr() as usize % align_of::<usize>(),
+			attributes._storage.as_ptr() as usize % align_of::<usize>(),
 			0
 		);
 		assert_eq!(
 			attributes.as_ptr().0,
-			attributes.storage.as_ptr().cast_mut().cast()
+			attributes._storage.as_ptr().cast_mut().cast()
 		);
 	}
 }

--- a/src/tokio/pty/windows/backend.rs
+++ b/src/tokio/pty/windows/backend.rs
@@ -24,8 +24,9 @@ pub(in crate::tokio::pty) fn spawn(
 
 	let input = PipePair::input()?;
 	let output = PipePair::output()?;
-	let mut console =
+	let console =
 		PseudoConsole::create(options.size, input.server_handle(), output.server_handle())?;
+	let release = console.releaser();
 	let (input_server, input_host) = input.into_parts();
 	let (output_server, output_host) = output.into_parts();
 	let attributes = AttributeList::new(console.handle())?;
@@ -34,7 +35,8 @@ pub(in crate::tokio::pty) fn spawn(
 	let spawned = catch_unwind(AssertUnwindSafe(|| {
 		let cleanup = &mut cleanup;
 		command.command.spawn_with_child(move |_inner| {
-			let spawned = process::spawn(prepared, &attributes, input_server, output_server)?;
+			let spawned =
+				process::spawn(prepared, &attributes, release, input_server, output_server)?;
 			*cleanup = Some(spawned.cleanup);
 			Ok(Box::new(spawned.child) as Box<dyn ChildWrapper>)
 		})
@@ -52,11 +54,6 @@ pub(in crate::tokio::pty) fn spawn(
 			resume_unwind(payload);
 		}
 	};
-	if let Err(error) = console.release() {
-		let _ = child.start_kill();
-		drop(cleanup.take());
-		return Err(error);
-	}
 	let (input, output, resize) = match controller::controller(console, input_host, output_host) {
 		Ok(controller) => controller,
 		Err(error) => {

--- a/src/tokio/pty/windows/backend.rs
+++ b/src/tokio/pty/windows/backend.rs
@@ -1,0 +1,70 @@
+//! End-to-end assembly of the Windows ConPTY backend.
+
+use std::{
+	io,
+	panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
+};
+
+use super::{
+	super::{ChildWrapper, PtyCommand, PtyController, PtyOptions},
+	attributes::AttributeList,
+	console::{self, PseudoConsole},
+	controller,
+	pipe::PipePair,
+	prepare, spawn as process,
+};
+
+pub(in crate::tokio::pty) fn spawn(
+	command: &mut PtyCommand,
+	options: PtyOptions,
+) -> io::Result<(Box<dyn ChildWrapper>, PtyController)> {
+	console::coordinate(options.size)?;
+	command.rebuild_command();
+	let prepared = prepare(command)?;
+
+	let input = PipePair::input()?;
+	let output = PipePair::output()?;
+	let mut console =
+		PseudoConsole::create(options.size, input.server_handle(), output.server_handle())?;
+	let (input_server, input_host) = input.into_parts();
+	let (output_server, output_host) = output.into_parts();
+	let attributes = AttributeList::new(console.handle())?;
+	let mut cleanup = None;
+
+	let spawned = catch_unwind(AssertUnwindSafe(|| {
+		let cleanup = &mut cleanup;
+		let console = &mut console;
+		command.command.spawn_with_child(move |_inner| {
+			let spawned = process::spawn(prepared, &attributes, input_server, output_server)?;
+			*cleanup = Some(spawned.cleanup);
+			console.release()?;
+			Ok(Box::new(spawned.child) as Box<dyn ChildWrapper>)
+		})
+	}));
+	command.rebuild_command();
+
+	let mut child = match spawned {
+		Ok(Ok(child)) => child,
+		Ok(Err(error)) => {
+			drop(cleanup.take());
+			return Err(error);
+		}
+		Err(payload) => {
+			drop(cleanup.take());
+			resume_unwind(payload);
+		}
+	};
+	let (input, output, resize) = match controller::controller(console, input_host, output_host) {
+		Ok(controller) => controller,
+		Err(error) => {
+			let _ = child.start_kill();
+			drop(cleanup.take());
+			return Err(error);
+		}
+	};
+	cleanup
+		.take()
+		.expect("a successful ConPTY spawn must install a cleanup guard")
+		.disarm();
+	Ok((child, PtyController::new(input, output, resize)))
+}

--- a/src/tokio/pty/windows/backend.rs
+++ b/src/tokio/pty/windows/backend.rs
@@ -35,8 +35,7 @@ pub(in crate::tokio::pty) fn spawn(
 	let spawned = catch_unwind(AssertUnwindSafe(|| {
 		let cleanup = &mut cleanup;
 		command.command.spawn_with_child(move |_inner| {
-			let spawned =
-				process::spawn(prepared, &attributes, release, input_server, output_server)?;
+			let spawned = process::spawn(prepared, &attributes, input_server, output_server)?;
 			*cleanup = Some(spawned.cleanup);
 			Ok(Box::new(spawned.child) as Box<dyn ChildWrapper>)
 		})
@@ -54,6 +53,11 @@ pub(in crate::tokio::pty) fn spawn(
 			resume_unwind(payload);
 		}
 	};
+	if let Err(error) = release.release() {
+		let _ = child.start_kill();
+		drop(cleanup.take());
+		return Err(error);
+	}
 	let (input, output, resize) = match controller::controller(console, input_host, output_host) {
 		Ok(controller) => controller,
 		Err(error) => {

--- a/src/tokio/pty/windows/backend.rs
+++ b/src/tokio/pty/windows/backend.rs
@@ -33,11 +33,9 @@ pub(in crate::tokio::pty) fn spawn(
 
 	let spawned = catch_unwind(AssertUnwindSafe(|| {
 		let cleanup = &mut cleanup;
-		let console = &mut console;
 		command.command.spawn_with_child(move |_inner| {
 			let spawned = process::spawn(prepared, &attributes, input_server, output_server)?;
 			*cleanup = Some(spawned.cleanup);
-			console.release()?;
 			Ok(Box::new(spawned.child) as Box<dyn ChildWrapper>)
 		})
 	}));
@@ -54,6 +52,11 @@ pub(in crate::tokio::pty) fn spawn(
 			resume_unwind(payload);
 		}
 	};
+	if let Err(error) = console.release() {
+		let _ = child.start_kill();
+		drop(cleanup.take());
+		return Err(error);
+	}
 	let (input, output, resize) = match controller::controller(console, input_host, output_host) {
 		Ok(controller) => controller,
 		Err(error) => {

--- a/src/tokio/pty/windows/child.rs
+++ b/src/tokio/pty/windows/child.rs
@@ -187,3 +187,131 @@ fn process_status(process: HANDLE, timeout: u32) -> io::Result<Option<ExitStatus
 		))),
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		os::windows::io::{AsRawHandle, FromRawHandle},
+		process::{Child, Command},
+		thread::sleep,
+		time::{Duration, Instant},
+	};
+
+	use super::*;
+
+	fn duplicate_process(child: &Child) -> OwnedHandle {
+		// SAFETY: the current-process pseudo-handle and child's process handle are live, and duplicate
+		// points to initialized writable storage. Ownership of the result is transferred once.
+		unsafe {
+			let current = GetCurrentProcess();
+			let mut duplicate = HANDLE::default();
+			DuplicateHandle(
+				current,
+				HANDLE(child.as_raw_handle()),
+				current,
+				&mut duplicate,
+				0,
+				false,
+				DUPLICATE_SAME_ACCESS,
+			)
+			.unwrap();
+			OwnedHandle::from_raw_handle(duplicate.0)
+		}
+	}
+
+	fn wrap(child: &Child, kill_on_drop: bool) -> ConPtyChild {
+		ConPtyChild {
+			process: duplicate_process(child),
+			primary_thread: None,
+			pid: child.id(),
+			kill_on_drop,
+			exit_status: ChildExitStatus::Running,
+			stdin: None,
+			stdout: None,
+			stderr: None,
+		}
+	}
+
+	fn spawn_exit_259() -> Child {
+		Command::new("cmd.exe")
+			.args(["/D", "/C", "exit /b 259"])
+			.spawn()
+			.unwrap()
+	}
+
+	fn spawn_long_running() -> Child {
+		Command::new("ping.exe")
+			.args(["-n", "30", "127.0.0.1"])
+			.spawn()
+			.unwrap()
+	}
+
+	fn wait_native(child: &mut Child) -> ExitStatus {
+		let deadline = Instant::now() + Duration::from_secs(5);
+		loop {
+			if let Some(status) = child.try_wait().unwrap() {
+				return status;
+			}
+			assert!(Instant::now() < deadline, "native test child did not exit");
+			sleep(Duration::from_millis(10));
+		}
+	}
+
+	#[tokio::test]
+	async fn preserves_exit_code_259_and_repeated_waits() {
+		let mut native = spawn_exit_259();
+		let mut child = wrap(&native, false);
+		assert_eq!(child.id(), Some(native.id()));
+		assert!(child.process_handle().is_some());
+		assert!(child.primary_thread_handle().is_none());
+		assert!((&child as &dyn ChildWrapper).try_inner_child().is_none());
+
+		let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
+			.await
+			.unwrap()
+			.unwrap();
+		assert_eq!(status.code(), Some(259));
+		assert_eq!(child.try_wait().unwrap(), Some(status));
+		assert_eq!(child.wait().await.unwrap(), status);
+		assert_eq!(wait_native(&mut native), status);
+	}
+
+	#[tokio::test]
+	async fn kills_and_reaps_the_direct_process() {
+		let mut native = spawn_long_running();
+		let mut child = wrap(&native, false);
+		assert!(child.try_wait().unwrap().is_none());
+		child.start_kill().unwrap();
+		let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
+			.await
+			.unwrap()
+			.unwrap();
+		assert_eq!(child.try_wait().unwrap(), Some(status));
+		assert_eq!(wait_native(&mut native), status);
+	}
+
+	#[tokio::test]
+	async fn canceled_async_wait_does_not_invalidate_the_process_handle() {
+		let mut native = spawn_long_running();
+		let mut child = wrap(&native, false);
+		assert!(
+			tokio::time::timeout(Duration::from_millis(20), child.wait())
+				.await
+				.is_err()
+		);
+		child.start_kill().unwrap();
+		let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
+			.await
+			.unwrap()
+			.unwrap();
+		assert_eq!(wait_native(&mut native), status);
+	}
+
+	#[test]
+	fn kill_on_drop_terminates_a_running_process() {
+		let mut native = spawn_long_running();
+		let child = wrap(&native, true);
+		drop(child);
+		let _ = wait_native(&mut native);
+	}
+}

--- a/src/tokio/pty/windows/child.rs
+++ b/src/tokio/pty/windows/child.rs
@@ -13,7 +13,7 @@ use std::{
 
 use tokio::{
 	process::{ChildStderr, ChildStdin, ChildStdout},
-	task::spawn_blocking,
+	task::{JoinHandle, spawn_blocking},
 };
 #[cfg(feature = "job-object")]
 use windows::Win32::System::Threading::ResumeThread;
@@ -36,6 +36,7 @@ pub(super) struct ConPtyChild {
 	pid: u32,
 	kill_on_drop: bool,
 	exit_status: ChildExitStatus,
+	wait_task: Option<JoinHandle<io::Result<ExitStatus>>>,
 	stdin: Option<ChildStdin>,
 	stdout: Option<ChildStdout>,
 	stderr: Option<ChildStderr>,
@@ -54,6 +55,7 @@ impl ConPtyChild {
 			pid,
 			kill_on_drop,
 			exit_status: ChildExitStatus::Running,
+			wait_task: None,
 			stdin: None,
 			stdout: None,
 			stderr: None,
@@ -139,6 +141,7 @@ impl ChildWrapper for ConPtyChild {
 		let status = process_status(self.raw_process_handle(), 0)?;
 		if let Some(status) = status {
 			self.exit_status = ChildExitStatus::Exited(status);
+			self.wait_task.take();
 		}
 		Ok(status)
 	}
@@ -149,14 +152,21 @@ impl ChildWrapper for ConPtyChild {
 				return Ok(status);
 			}
 
-			let process = duplicate_handle(&self.process)?;
-			let status = spawn_blocking(move || {
-				process_status(HANDLE(process.as_raw_handle()), INFINITE)?.ok_or_else(|| {
-					io::Error::other("infinite process wait returned without an exit status")
-				})
-			})
-			.await
-			.map_err(io::Error::other)??;
+			if self.wait_task.is_none() {
+				let process = duplicate_handle(&self.process)?;
+				self.wait_task = Some(spawn_blocking(move || {
+					process_status(HANDLE(process.as_raw_handle()), INFINITE)?.ok_or_else(|| {
+						io::Error::other("infinite process wait returned without an exit status")
+					})
+				}));
+			}
+			let result = self
+				.wait_task
+				.as_mut()
+				.expect("an in-progress ConPTY wait must retain its task")
+				.await;
+			self.wait_task.take();
+			let status = result.map_err(io::Error::other)??;
 			self.exit_status = ChildExitStatus::Exited(status);
 			Ok(status)
 		})
@@ -251,6 +261,7 @@ mod tests {
 			pid: child.id(),
 			kill_on_drop,
 			exit_status: ChildExitStatus::Running,
+			wait_task: None,
 			stdin: None,
 			stdout: None,
 			stderr: None,
@@ -316,7 +327,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn canceled_async_wait_does_not_invalidate_the_process_handle() {
+	async fn canceled_async_waits_share_one_task_and_preserve_the_process_handle() {
 		let mut native = spawn_long_running();
 		let mut child = wrap(&native, false);
 		assert!(
@@ -324,6 +335,26 @@ mod tests {
 				.await
 				.is_err()
 		);
+		let wait_id = child
+			.wait_task
+			.as_ref()
+			.expect("a canceled wait must retain its task")
+			.id();
+		for _ in 0..7 {
+			assert!(
+				tokio::time::timeout(Duration::from_millis(20), child.wait())
+					.await
+					.is_err()
+			);
+			assert_eq!(
+				child
+					.wait_task
+					.as_ref()
+					.expect("a canceled wait must retain its task")
+					.id(),
+				wait_id
+			);
+		}
 		child.start_kill().unwrap();
 		let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
 			.await

--- a/src/tokio/pty/windows/child.rs
+++ b/src/tokio/pty/windows/child.rs
@@ -20,7 +20,8 @@ use windows::Win32::{
 		DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
 	},
 	System::Threading::{
-		GetCurrentProcess, GetExitCodeProcess, INFINITE, TerminateProcess, WaitForSingleObject,
+		GetCurrentProcess, GetExitCodeProcess, INFINITE, ResumeThread, TerminateProcess,
+		WaitForSingleObject,
 	},
 };
 
@@ -59,6 +60,26 @@ impl ConPtyChild {
 
 	pub(super) fn primary_thread_handle(&self) -> Option<BorrowedHandle<'_>> {
 		self.primary_thread.as_ref().map(OwnedHandle::as_handle)
+	}
+
+	pub(super) fn resume_primary_thread(&mut self) -> io::Result<()> {
+		let thread = self
+			.primary_thread
+			.take()
+			.ok_or_else(|| io::Error::other("ConPTY child has no primary thread handle"))?;
+		// SAFETY: thread is the live primary-thread handle returned by CreateProcessW.
+		let previous_count = unsafe { ResumeThread(HANDLE(thread.as_raw_handle())) };
+		match previous_count {
+			u32::MAX => Err(io::Error::last_os_error()),
+			1 => Ok(()),
+			0 => Err(io::Error::other(
+				"ConPTY primary thread was not suspended for job assignment",
+			)),
+			count => Err(io::Error::other(format!(
+				"ConPTY primary thread remains suspended with count {}",
+				count - 1
+			))),
+		}
 	}
 
 	fn raw_process_handle(&self) -> HANDLE {

--- a/src/tokio/pty/windows/child.rs
+++ b/src/tokio/pty/windows/child.rs
@@ -28,8 +28,6 @@ use windows::Win32::{
 
 use crate::{ChildExitStatus, tokio::ChildWrapper};
 
-use super::console::Release;
-
 #[derive(Debug)]
 pub(super) struct ConPtyChild {
 	process: OwnedHandle,
@@ -50,28 +48,18 @@ impl ConPtyChild {
 		primary_thread: OwnedHandle,
 		pid: u32,
 		kill_on_drop: bool,
-		release: Release,
-	) -> io::Result<Self> {
-		let wait_process = duplicate_handle(&process)?;
-		let wait_task = spawn_blocking(move || {
-			let status = process_status(HANDLE(wait_process.as_raw_handle()), INFINITE)?
-				.ok_or_else(|| {
-					io::Error::other("infinite process wait returned without an exit status")
-				})?;
-			let _ = release.release();
-			Ok(status)
-		});
-		Ok(Self {
+	) -> Self {
+		Self {
 			process,
 			primary_thread: Some(primary_thread),
 			pid,
 			kill_on_drop,
 			exit_status: ChildExitStatus::Running,
-			wait_task: Some(wait_task),
+			wait_task: None,
 			stdin: None,
 			stdout: None,
 			stderr: None,
-		})
+		}
 	}
 
 	#[cfg(test)]

--- a/src/tokio/pty/windows/child.rs
+++ b/src/tokio/pty/windows/child.rs
@@ -15,13 +15,14 @@ use tokio::{
 	process::{ChildStderr, ChildStdin, ChildStdout},
 	task::spawn_blocking,
 };
+#[cfg(feature = "job-object")]
+use windows::Win32::System::Threading::ResumeThread;
 use windows::Win32::{
 	Foundation::{
 		DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
 	},
 	System::Threading::{
-		GetCurrentProcess, GetExitCodeProcess, INFINITE, ResumeThread, TerminateProcess,
-		WaitForSingleObject,
+		GetCurrentProcess, GetExitCodeProcess, INFINITE, TerminateProcess, WaitForSingleObject,
 	},
 };
 
@@ -30,6 +31,7 @@ use crate::{ChildExitStatus, tokio::ChildWrapper};
 #[derive(Debug)]
 pub(super) struct ConPtyChild {
 	process: OwnedHandle,
+	#[cfg_attr(not(feature = "job-object"), allow(dead_code))]
 	primary_thread: Option<OwnedHandle>,
 	pid: u32,
 	kill_on_drop: bool,
@@ -58,10 +60,12 @@ impl ConPtyChild {
 		}
 	}
 
+	#[cfg(test)]
 	pub(super) fn primary_thread_handle(&self) -> Option<BorrowedHandle<'_>> {
 		self.primary_thread.as_ref().map(OwnedHandle::as_handle)
 	}
 
+	#[cfg(feature = "job-object")]
 	pub(super) fn resume_primary_thread(&mut self) -> io::Result<()> {
 		let thread = self
 			.primary_thread

--- a/src/tokio/pty/windows/child.rs
+++ b/src/tokio/pty/windows/child.rs
@@ -1,0 +1,189 @@
+//! A terminal [`ChildWrapper`] backed directly by Win32 process handles.
+
+use std::{
+	future::Future,
+	io,
+	os::windows::{
+		io::{AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, OwnedHandle},
+		process::ExitStatusExt,
+	},
+	pin::Pin,
+	process::ExitStatus,
+};
+
+use tokio::{
+	process::{ChildStderr, ChildStdin, ChildStdout},
+	task::spawn_blocking,
+};
+use windows::Win32::{
+	Foundation::{
+		DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+	},
+	System::Threading::{
+		GetCurrentProcess, GetExitCodeProcess, INFINITE, TerminateProcess, WaitForSingleObject,
+	},
+};
+
+use crate::{ChildExitStatus, tokio::ChildWrapper};
+
+#[derive(Debug)]
+pub(super) struct ConPtyChild {
+	process: OwnedHandle,
+	primary_thread: Option<OwnedHandle>,
+	pid: u32,
+	kill_on_drop: bool,
+	exit_status: ChildExitStatus,
+	stdin: Option<ChildStdin>,
+	stdout: Option<ChildStdout>,
+	stderr: Option<ChildStderr>,
+}
+
+impl ConPtyChild {
+	pub(super) fn new(
+		process: OwnedHandle,
+		primary_thread: OwnedHandle,
+		pid: u32,
+		kill_on_drop: bool,
+	) -> Self {
+		Self {
+			process,
+			primary_thread: Some(primary_thread),
+			pid,
+			kill_on_drop,
+			exit_status: ChildExitStatus::Running,
+			stdin: None,
+			stdout: None,
+			stderr: None,
+		}
+	}
+
+	pub(super) fn primary_thread_handle(&self) -> Option<BorrowedHandle<'_>> {
+		self.primary_thread.as_ref().map(OwnedHandle::as_handle)
+	}
+
+	fn raw_process_handle(&self) -> HANDLE {
+		HANDLE(self.process.as_raw_handle())
+	}
+}
+
+impl ChildWrapper for ConPtyChild {
+	fn inner(&self) -> &dyn ChildWrapper {
+		self
+	}
+
+	fn inner_mut(&mut self) -> &mut dyn ChildWrapper {
+		self
+	}
+
+	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
+		self
+	}
+
+	fn process_handle(&self) -> Option<BorrowedHandle<'_>> {
+		Some(self.process.as_handle())
+	}
+
+	fn stdin(&mut self) -> &mut Option<ChildStdin> {
+		&mut self.stdin
+	}
+
+	fn stdout(&mut self) -> &mut Option<ChildStdout> {
+		&mut self.stdout
+	}
+
+	fn stderr(&mut self) -> &mut Option<ChildStderr> {
+		&mut self.stderr
+	}
+
+	fn id(&self) -> Option<u32> {
+		Some(self.pid)
+	}
+
+	fn start_kill(&mut self) -> io::Result<()> {
+		if self.try_wait()?.is_some() {
+			return Ok(());
+		}
+		// SAFETY: self owns a live process handle with process-termination access.
+		unsafe { TerminateProcess(self.raw_process_handle(), 1) }.map_err(io::Error::other)
+	}
+
+	fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+		if let ChildExitStatus::Exited(status) = self.exit_status {
+			return Ok(Some(status));
+		}
+		let status = process_status(self.raw_process_handle(), 0)?;
+		if let Some(status) = status {
+			self.exit_status = ChildExitStatus::Exited(status);
+		}
+		Ok(status)
+	}
+
+	fn wait(&mut self) -> Pin<Box<dyn Future<Output = io::Result<ExitStatus>> + Send + '_>> {
+		Box::pin(async move {
+			if let ChildExitStatus::Exited(status) = self.exit_status {
+				return Ok(status);
+			}
+
+			let process = duplicate_handle(&self.process)?;
+			let status = spawn_blocking(move || {
+				process_status(HANDLE(process.as_raw_handle()), INFINITE)?.ok_or_else(|| {
+					io::Error::other("infinite process wait returned without an exit status")
+				})
+			})
+			.await
+			.map_err(io::Error::other)??;
+			self.exit_status = ChildExitStatus::Exited(status);
+			Ok(status)
+		})
+	}
+}
+
+impl Drop for ConPtyChild {
+	fn drop(&mut self) {
+		if self.kill_on_drop
+			&& matches!(self.exit_status, ChildExitStatus::Running)
+			&& !matches!(process_status(self.raw_process_handle(), 0), Ok(Some(_)))
+		{
+			// SAFETY: self still owns the process handle for the duration of this call.
+			let _ = unsafe { TerminateProcess(self.raw_process_handle(), 1) };
+		}
+	}
+}
+
+fn duplicate_handle(handle: &OwnedHandle) -> io::Result<OwnedHandle> {
+	// SAFETY: GetCurrentProcess returns a permanent pseudo-handle. The source handle is live, and the
+	// output pointer is writable. The resulting non-inheritable duplicate is transferred once.
+	unsafe {
+		let process = GetCurrentProcess();
+		let mut duplicate = HANDLE::default();
+		DuplicateHandle(
+			process,
+			HANDLE(handle.as_raw_handle()),
+			process,
+			&mut duplicate,
+			0,
+			false,
+			DUPLICATE_SAME_ACCESS,
+		)
+		.map_err(io::Error::other)?;
+		Ok(OwnedHandle::from_raw_handle(duplicate.0))
+	}
+}
+
+fn process_status(process: HANDLE, timeout: u32) -> io::Result<Option<ExitStatus>> {
+	// SAFETY: process is a live process handle and timeout has the documented wait semantics.
+	match unsafe { WaitForSingleObject(process, timeout) } {
+		WAIT_TIMEOUT => Ok(None),
+		WAIT_OBJECT_0 => {
+			let mut code = 0;
+			// SAFETY: the process is signaled and code points to initialized writable storage.
+			unsafe { GetExitCodeProcess(process, &mut code) }.map_err(io::Error::other)?;
+			Ok(Some(ExitStatus::from_raw(code)))
+		}
+		WAIT_FAILED => Err(io::Error::last_os_error()),
+		other => Err(io::Error::other(format!(
+			"unexpected process wait result {}",
+			other.0
+		))),
+	}
+}

--- a/src/tokio/pty/windows/child.rs
+++ b/src/tokio/pty/windows/child.rs
@@ -28,6 +28,8 @@ use windows::Win32::{
 
 use crate::{ChildExitStatus, tokio::ChildWrapper};
 
+use super::console::Release;
+
 #[derive(Debug)]
 pub(super) struct ConPtyChild {
 	process: OwnedHandle,
@@ -48,18 +50,28 @@ impl ConPtyChild {
 		primary_thread: OwnedHandle,
 		pid: u32,
 		kill_on_drop: bool,
-	) -> Self {
-		Self {
+		release: Release,
+	) -> io::Result<Self> {
+		let wait_process = duplicate_handle(&process)?;
+		let wait_task = spawn_blocking(move || {
+			let status = process_status(HANDLE(wait_process.as_raw_handle()), INFINITE)?
+				.ok_or_else(|| {
+					io::Error::other("infinite process wait returned without an exit status")
+				})?;
+			let _ = release.release();
+			Ok(status)
+		});
+		Ok(Self {
 			process,
 			primary_thread: Some(primary_thread),
 			pid,
 			kill_on_drop,
 			exit_status: ChildExitStatus::Running,
-			wait_task: None,
+			wait_task: Some(wait_task),
 			stdin: None,
 			stdout: None,
 			stderr: None,
-		}
+		})
 	}
 
 	#[cfg(test)]

--- a/src/tokio/pty/windows/command.rs
+++ b/src/tokio/pty/windows/command.rs
@@ -34,6 +34,7 @@ impl WideCString {
 		self.0.as_mut_ptr()
 	}
 
+	#[cfg(test)]
 	pub(super) fn as_units(&self) -> &[u16] {
 		&self.0
 	}

--- a/src/tokio/pty/windows/console.rs
+++ b/src/tokio/pty/windows/console.rs
@@ -22,6 +22,7 @@ use super::{
 pub(super) struct PseudoConsole {
 	handle: HPCON,
 	api: &'static ConPtyApi,
+	released: bool,
 }
 
 impl PseudoConsole {
@@ -46,11 +47,27 @@ impl PseudoConsole {
 				"CreatePseudoConsole returned an invalid handle",
 			));
 		}
-		Ok(Self { handle, api })
+		Ok(Self {
+			handle,
+			api,
+			released: false,
+		})
 	}
 
 	pub(super) fn handle(&self) -> HPCON {
 		self.handle
+	}
+
+	pub(super) fn release(&mut self) -> io::Result<()> {
+		if self.released {
+			return Ok(());
+		}
+		// SAFETY: self owns a live pseudo-console and the resolved function has the documented ABI.
+		unsafe { (self.api.release)(self.handle) }
+			.ok()
+			.map_err(io::Error::other)?;
+		self.released = true;
+		Ok(())
 	}
 
 	pub(super) fn resize(&self, size: PtySize) -> io::Result<()> {
@@ -139,6 +156,7 @@ mod tests {
 	static CREATE_SIZE: AtomicU32 = AtomicU32::new(0);
 	static CREATE_FLAGS: AtomicU32 = AtomicU32::new(u32::MAX);
 	static RESIZE_SIZE: AtomicU32 = AtomicU32::new(0);
+	static RELEASE_COUNT: AtomicUsize = AtomicUsize::new(0);
 	static BLOCK_CLOSE: AtomicBool = AtomicBool::new(false);
 	static CLOSE_STARTED: AtomicBool = AtomicBool::new(false);
 	static CLOSE_COUNT: AtomicUsize = AtomicUsize::new(0);
@@ -162,6 +180,11 @@ mod tests {
 		HRESULT(0)
 	}
 
+	unsafe extern "system" fn release(_pseudo_console: HPCON) -> HRESULT {
+		RELEASE_COUNT.fetch_add(1, Ordering::SeqCst);
+		HRESULT(0)
+	}
+
 	unsafe extern "system" fn close(_pseudo_console: HPCON) {
 		CLOSE_STARTED.store(true, Ordering::SeqCst);
 		for _ in 0..1_000 {
@@ -176,6 +199,7 @@ mod tests {
 	static TEST_API: ConPtyApi = ConPtyApi {
 		create,
 		resize,
+		release,
 		close,
 	};
 
@@ -194,6 +218,7 @@ mod tests {
 	}
 
 	fn reset_close() {
+		RELEASE_COUNT.store(0, Ordering::SeqCst);
 		BLOCK_CLOSE.store(false, Ordering::SeqCst);
 		CLOSE_STARTED.store(false, Ordering::SeqCst);
 		CLOSE_COUNT.store(0, Ordering::SeqCst);
@@ -239,7 +264,7 @@ mod tests {
 		CREATE_FLAGS.store(u32::MAX, Ordering::SeqCst);
 		RESIZE_SIZE.store(0, Ordering::SeqCst);
 
-		let console = PseudoConsole::create_with(
+		let mut console = PseudoConsole::create_with(
 			&TEST_API,
 			PtySize::new(25, 81).unwrap(),
 			HANDLE(1usize as _),
@@ -257,6 +282,9 @@ mod tests {
 			RESIZE_SIZE.load(Ordering::SeqCst),
 			pack(COORD { X: 120, Y: 40 })
 		);
+		console.release().unwrap();
+		console.release().unwrap();
+		assert_eq!(RELEASE_COUNT.load(Ordering::SeqCst), 1);
 
 		drop(console);
 		wait_for(|| CLOSE_COUNT.load(Ordering::SeqCst) == 1);
@@ -270,6 +298,7 @@ mod tests {
 		let console = PseudoConsole {
 			handle: HPCON(42),
 			api: &TEST_API,
+			released: false,
 		};
 
 		let started = Instant::now();

--- a/src/tokio/pty/windows/console.rs
+++ b/src/tokio/pty/windows/console.rs
@@ -123,3 +123,164 @@ fn schedule_close(close: api::ClosePseudoConsole, handle: HPCON) {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
+		time::{Duration, Instant},
+	};
+
+	use windows::core::HRESULT;
+
+	use super::*;
+
+	static TEST_LOCK: Mutex<()> = Mutex::new(());
+	static CREATE_SIZE: AtomicU32 = AtomicU32::new(0);
+	static CREATE_FLAGS: AtomicU32 = AtomicU32::new(u32::MAX);
+	static RESIZE_SIZE: AtomicU32 = AtomicU32::new(0);
+	static BLOCK_CLOSE: AtomicBool = AtomicBool::new(false);
+	static CLOSE_STARTED: AtomicBool = AtomicBool::new(false);
+	static CLOSE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+	unsafe extern "system" fn create(
+		size: COORD,
+		_input: HANDLE,
+		_output: HANDLE,
+		flags: u32,
+		pseudo_console: *mut HPCON,
+	) -> HRESULT {
+		CREATE_SIZE.store(pack(size), Ordering::SeqCst);
+		CREATE_FLAGS.store(flags, Ordering::SeqCst);
+		// SAFETY: the test caller passes writable storage for the output handle.
+		unsafe { *pseudo_console = HPCON(42) };
+		HRESULT(0)
+	}
+
+	unsafe extern "system" fn resize(_pseudo_console: HPCON, size: COORD) -> HRESULT {
+		RESIZE_SIZE.store(pack(size), Ordering::SeqCst);
+		HRESULT(0)
+	}
+
+	unsafe extern "system" fn close(_pseudo_console: HPCON) {
+		CLOSE_STARTED.store(true, Ordering::SeqCst);
+		for _ in 0..1_000 {
+			if !BLOCK_CLOSE.load(Ordering::SeqCst) {
+				break;
+			}
+			std::thread::sleep(Duration::from_millis(1));
+		}
+		CLOSE_COUNT.fetch_add(1, Ordering::SeqCst);
+	}
+
+	static TEST_API: ConPtyApi = ConPtyApi {
+		create,
+		resize,
+		close,
+	};
+
+	fn pack(size: COORD) -> u32 {
+		u32::from(size.X as u16) | (u32::from(size.Y as u16) << 16)
+	}
+
+	fn wait_for(predicate: impl Fn() -> bool) {
+		for _ in 0..1_000 {
+			if predicate() {
+				return;
+			}
+			std::thread::sleep(Duration::from_millis(1));
+		}
+		panic!("timed out waiting for mock ConPTY operation");
+	}
+
+	fn reset_close() {
+		BLOCK_CLOSE.store(false, Ordering::SeqCst);
+		CLOSE_STARTED.store(false, Ordering::SeqCst);
+		CLOSE_COUNT.store(0, Ordering::SeqCst);
+	}
+
+	#[test]
+	fn converts_character_dimensions_and_rejects_windows_overflow() {
+		assert_eq!(
+			coordinate(PtySize::new(24, 80).unwrap()).unwrap(),
+			COORD { X: 80, Y: 24 }
+		);
+		let columns = coordinate(PtySize {
+			rows: 1,
+			columns: 32_768,
+			pixel_width: 0,
+			pixel_height: 0,
+		})
+		.unwrap_err();
+		assert_eq!(columns.kind(), io::ErrorKind::InvalidInput);
+		assert_eq!(
+			columns.to_string(),
+			"PTY columns must not exceed 32767 on Windows"
+		);
+		let rows = coordinate(PtySize {
+			rows: 32_768,
+			columns: 1,
+			pixel_width: 0,
+			pixel_height: 0,
+		})
+		.unwrap_err();
+		assert_eq!(rows.kind(), io::ErrorKind::InvalidInput);
+		assert_eq!(
+			rows.to_string(),
+			"PTY rows must not exceed 32767 on Windows"
+		);
+	}
+
+	#[test]
+	fn creates_and_resizes_through_the_resolved_capabilities() {
+		let _serial = TEST_LOCK.lock().unwrap();
+		reset_close();
+		CREATE_SIZE.store(0, Ordering::SeqCst);
+		CREATE_FLAGS.store(u32::MAX, Ordering::SeqCst);
+		RESIZE_SIZE.store(0, Ordering::SeqCst);
+
+		let console = PseudoConsole::create_with(
+			&TEST_API,
+			PtySize::new(25, 81).unwrap(),
+			HANDLE(1usize as _),
+			HANDLE(2usize as _),
+		)
+		.unwrap();
+		assert_eq!(console.handle(), HPCON(42));
+		assert_eq!(
+			CREATE_SIZE.load(Ordering::SeqCst),
+			pack(COORD { X: 81, Y: 25 })
+		);
+		assert_eq!(CREATE_FLAGS.load(Ordering::SeqCst), 0);
+		console.resize(PtySize::new(40, 120).unwrap()).unwrap();
+		assert_eq!(
+			RESIZE_SIZE.load(Ordering::SeqCst),
+			pack(COORD { X: 120, Y: 40 })
+		);
+
+		drop(console);
+		wait_for(|| CLOSE_COUNT.load(Ordering::SeqCst) == 1);
+	}
+
+	#[test]
+	fn drop_schedules_exactly_one_close_away_from_the_caller() {
+		let _serial = TEST_LOCK.lock().unwrap();
+		reset_close();
+		BLOCK_CLOSE.store(true, Ordering::SeqCst);
+		let console = PseudoConsole {
+			handle: HPCON(42),
+			api: &TEST_API,
+		};
+
+		let started = Instant::now();
+		drop(console);
+		assert!(started.elapsed() < Duration::from_millis(250));
+		wait_for(|| CLOSE_STARTED.load(Ordering::SeqCst));
+		assert_eq!(CLOSE_COUNT.load(Ordering::SeqCst), 0);
+
+		BLOCK_CLOSE.store(false, Ordering::SeqCst);
+		wait_for(|| CLOSE_COUNT.load(Ordering::SeqCst) == 1);
+		std::thread::sleep(Duration::from_millis(10));
+		assert_eq!(CLOSE_COUNT.load(Ordering::SeqCst), 1);
+	}
+}

--- a/src/tokio/pty/windows/console.rs
+++ b/src/tokio/pty/windows/console.rs
@@ -1,0 +1,125 @@
+//! Dynamically owned pseudo-console handles, resizing, and off-thread close cleanup.
+
+use std::{
+	io,
+	sync::{Mutex, OnceLock},
+	thread::JoinHandle,
+};
+
+#[cfg(feature = "tracing")]
+use tracing::warn;
+use windows::Win32::{
+	Foundation::HANDLE,
+	System::Console::{COORD, HPCON},
+};
+
+use super::{
+	super::PtySize,
+	api::{self, ConPtyApi},
+};
+
+#[derive(Debug)]
+pub(super) struct PseudoConsole {
+	handle: HPCON,
+	api: &'static ConPtyApi,
+}
+
+impl PseudoConsole {
+	pub(super) fn create(size: PtySize, input: HANDLE, output: HANDLE) -> io::Result<Self> {
+		Self::create_with(api::get()?, size, input, output)
+	}
+
+	fn create_with(
+		api: &'static ConPtyApi,
+		size: PtySize,
+		input: HANDLE,
+		output: HANDLE,
+	) -> io::Result<Self> {
+		let mut handle = HPCON::default();
+		// SAFETY: input and output are live synchronous pipe handles, handle points to initialized
+		// writable storage, and the resolved function has the documented ConPTY ABI.
+		unsafe { (api.create)(coordinate(size)?, input, output, 0, &mut handle) }
+			.ok()
+			.map_err(io::Error::other)?;
+		if handle.is_invalid() {
+			return Err(io::Error::other(
+				"CreatePseudoConsole returned an invalid handle",
+			));
+		}
+		Ok(Self { handle, api })
+	}
+
+	pub(super) fn handle(&self) -> HPCON {
+		self.handle
+	}
+
+	pub(super) fn resize(&self, size: PtySize) -> io::Result<()> {
+		// SAFETY: self owns a live pseudo-console and the resolved function has the documented ABI.
+		unsafe { (self.api.resize)(self.handle, coordinate(size)?) }
+			.ok()
+			.map_err(io::Error::other)
+	}
+}
+
+impl Drop for PseudoConsole {
+	fn drop(&mut self) {
+		schedule_close(self.api.close, self.handle);
+	}
+}
+
+pub(super) fn coordinate(size: PtySize) -> io::Result<COORD> {
+	size.validate()?;
+	let columns = i16::try_from(size.columns).map_err(|_| {
+		io::Error::new(
+			io::ErrorKind::InvalidInput,
+			"PTY columns must not exceed 32767 on Windows",
+		)
+	})?;
+	let rows = i16::try_from(size.rows).map_err(|_| {
+		io::Error::new(
+			io::ErrorKind::InvalidInput,
+			"PTY rows must not exceed 32767 on Windows",
+		)
+	})?;
+	Ok(COORD {
+		X: columns,
+		Y: rows,
+	})
+}
+
+fn schedule_close(close: api::ClosePseudoConsole, handle: HPCON) {
+	static CLOSE_THREADS: OnceLock<Mutex<Vec<JoinHandle<()>>>> = OnceLock::new();
+	let threads = CLOSE_THREADS.get_or_init(|| Mutex::new(Vec::new()));
+	let mut threads = threads.lock().unwrap_or_else(|poison| poison.into_inner());
+	let mut index = 0;
+	while index < threads.len() {
+		if threads[index].is_finished() {
+			let finished = threads.swap_remove(index);
+			let _ = finished.join();
+		} else {
+			index += 1;
+		}
+	}
+
+	let close_thread = std::thread::Builder::new()
+		.name("process-wrap-conpty-close".into())
+		.spawn(move || {
+			// SAFETY: ownership of this live raw HPCON was transferred to exactly this close thread.
+			unsafe { close(handle) };
+		});
+	match close_thread {
+		Ok(close_thread) => threads.push(close_thread),
+		Err(error) => {
+			// Calling ClosePseudoConsole here could indefinitely block a reactor or arbitrary dropping
+			// thread on older Windows versions. Leaking is the only safe fallback after thread creation
+			// itself fails.
+			#[cfg(feature = "tracing")]
+			warn!(
+				?error,
+				"failed to start ConPTY close thread; leaking the pseudo-console handle"
+			);
+			#[cfg(not(feature = "tracing"))]
+			let _ = error;
+		}
+	}
+}

--- a/src/tokio/pty/windows/console.rs
+++ b/src/tokio/pty/windows/console.rs
@@ -93,14 +93,13 @@ impl PseudoConsole {
 			.lifecycle
 			.lock()
 			.unwrap_or_else(|poison| poison.into_inner());
-		if lifecycle.released || lifecycle.closed {
+		if lifecycle.closed {
 			return Err(io::Error::new(
 				io::ErrorKind::BrokenPipe,
-				"the pseudo-console is no longer application-owned",
+				"the pseudo-console is closed",
 			));
 		}
-		// SAFETY: the application still owns this live pseudo-console and the resolved function has
-		// the documented ABI.
+		// SAFETY: this is a live pseudo-console and the resolved function has the documented ABI.
 		unsafe { (self.state.api.resize)(self.state.handle, coordinate(size)?) }
 			.ok()
 			.map_err(io::Error::other)
@@ -344,6 +343,11 @@ mod tests {
 		console.release().unwrap();
 		console.release().unwrap();
 		assert_eq!(RELEASE_COUNT.load(Ordering::SeqCst), 1);
+		console.resize(PtySize::new(41, 121).unwrap()).unwrap();
+		assert_eq!(
+			RESIZE_SIZE.load(Ordering::SeqCst),
+			pack(COORD { X: 121, Y: 41 })
+		);
 
 		drop(console);
 		wait_for(|| CLOSE_COUNT.load(Ordering::SeqCst) == 1);

--- a/src/tokio/pty/windows/console.rs
+++ b/src/tokio/pty/windows/console.rs
@@ -2,7 +2,7 @@
 
 use std::{
 	io,
-	sync::{Mutex, OnceLock},
+	sync::{Arc, Mutex, OnceLock},
 	thread::JoinHandle,
 };
 
@@ -20,9 +20,25 @@ use super::{
 
 #[derive(Debug)]
 pub(super) struct PseudoConsole {
+	state: Arc<State>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Release {
+	state: Arc<State>,
+}
+
+#[derive(Debug)]
+struct State {
 	handle: HPCON,
 	api: &'static ConPtyApi,
+	lifecycle: Mutex<Lifecycle>,
+}
+
+#[derive(Debug, Default)]
+struct Lifecycle {
 	released: bool,
+	closed: bool,
 }
 
 impl PseudoConsole {
@@ -48,39 +64,82 @@ impl PseudoConsole {
 			));
 		}
 		Ok(Self {
-			handle,
-			api,
-			released: false,
+			state: Arc::new(State {
+				handle,
+				api,
+				lifecycle: Mutex::new(Lifecycle::default()),
+			}),
 		})
 	}
 
 	pub(super) fn handle(&self) -> HPCON {
-		self.handle
+		self.state.handle
 	}
 
-	pub(super) fn release(&mut self) -> io::Result<()> {
-		if self.released {
-			return Ok(());
+	pub(super) fn releaser(&self) -> Release {
+		Release {
+			state: Arc::clone(&self.state),
 		}
-		// SAFETY: self owns a live pseudo-console and the resolved function has the documented ABI.
-		unsafe { (self.api.release)(self.handle) }
-			.ok()
-			.map_err(io::Error::other)?;
-		self.released = true;
-		Ok(())
+	}
+
+	#[cfg(test)]
+	fn release(&self) -> io::Result<()> {
+		self.releaser().release()
 	}
 
 	pub(super) fn resize(&self, size: PtySize) -> io::Result<()> {
-		// SAFETY: self owns a live pseudo-console and the resolved function has the documented ABI.
-		unsafe { (self.api.resize)(self.handle, coordinate(size)?) }
+		let lifecycle = self
+			.state
+			.lifecycle
+			.lock()
+			.unwrap_or_else(|poison| poison.into_inner());
+		if lifecycle.released || lifecycle.closed {
+			return Err(io::Error::new(
+				io::ErrorKind::BrokenPipe,
+				"the pseudo-console is no longer application-owned",
+			));
+		}
+		// SAFETY: the application still owns this live pseudo-console and the resolved function has
+		// the documented ABI.
+		unsafe { (self.state.api.resize)(self.state.handle, coordinate(size)?) }
 			.ok()
 			.map_err(io::Error::other)
 	}
 }
 
+impl Release {
+	pub(super) fn release(&self) -> io::Result<()> {
+		let mut lifecycle = self
+			.state
+			.lifecycle
+			.lock()
+			.unwrap_or_else(|poison| poison.into_inner());
+		if lifecycle.released || lifecycle.closed {
+			return Ok(());
+		}
+		// SAFETY: the application owns this live pseudo-console and the resolved function has the
+		// documented ABI.
+		unsafe { (self.state.api.release)(self.state.handle) }
+			.ok()
+			.map_err(io::Error::other)?;
+		lifecycle.released = true;
+		Ok(())
+	}
+}
+
 impl Drop for PseudoConsole {
 	fn drop(&mut self) {
-		schedule_close(self.api.close, self.handle);
+		let mut lifecycle = self
+			.state
+			.lifecycle
+			.lock()
+			.unwrap_or_else(|poison| poison.into_inner());
+		if lifecycle.closed {
+			return;
+		}
+		lifecycle.closed = true;
+		drop(lifecycle);
+		schedule_close(self.state.api.close, self.state.handle);
 	}
 }
 
@@ -264,7 +323,7 @@ mod tests {
 		CREATE_FLAGS.store(u32::MAX, Ordering::SeqCst);
 		RESIZE_SIZE.store(0, Ordering::SeqCst);
 
-		let mut console = PseudoConsole::create_with(
+		let console = PseudoConsole::create_with(
 			&TEST_API,
 			PtySize::new(25, 81).unwrap(),
 			HANDLE(1usize as _),
@@ -296,9 +355,11 @@ mod tests {
 		reset_close();
 		BLOCK_CLOSE.store(true, Ordering::SeqCst);
 		let console = PseudoConsole {
-			handle: HPCON(42),
-			api: &TEST_API,
-			released: false,
+			state: Arc::new(State {
+				handle: HPCON(42),
+				api: &TEST_API,
+				lifecycle: Mutex::new(Lifecycle::default()),
+			}),
 		};
 
 		let started = Instant::now();

--- a/src/tokio/pty/windows/controller.rs
+++ b/src/tokio/pty/windows/controller.rs
@@ -1,0 +1,164 @@
+//! Shared Windows PTY controller ownership and Tokio named-pipe I/O.
+
+use std::{
+	io,
+	os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle},
+	pin::Pin,
+	sync::{Arc, Weak},
+	task::{Context, Poll},
+};
+
+use tokio::{
+	io::{AsyncRead, AsyncWrite, ReadBuf},
+	net::windows::named_pipe::NamedPipeClient,
+};
+use windows::Win32::{
+	Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE},
+	System::Threading::GetCurrentProcess,
+};
+
+use super::{super::PtySize, console::PseudoConsole};
+
+type SharedMaster = Arc<Master>;
+
+#[derive(Debug)]
+struct Master {
+	_input_lifetime: OwnedHandle,
+	_output_lifetime: OwnedHandle,
+	console: PseudoConsole,
+}
+
+#[derive(Debug)]
+pub(super) struct Input {
+	pipe: Option<NamedPipeClient>,
+	master: Option<SharedMaster>,
+}
+
+impl AsyncWrite for Input {
+	fn poll_write(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buffer: &[u8],
+	) -> Poll<io::Result<usize>> {
+		let Some(pipe) = self.pipe.as_mut() else {
+			return Poll::Ready(Err(closed()));
+		};
+		Pin::new(pipe).poll_write(cx, buffer)
+	}
+
+	fn poll_write_vectored(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buffers: &[io::IoSlice<'_>],
+	) -> Poll<io::Result<usize>> {
+		let Some(pipe) = self.pipe.as_mut() else {
+			return Poll::Ready(Err(closed()));
+		};
+		Pin::new(pipe).poll_write_vectored(cx, buffers)
+	}
+
+	fn is_write_vectored(&self) -> bool {
+		self.pipe
+			.as_ref()
+			.is_some_and(AsyncWrite::is_write_vectored)
+	}
+
+	fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		let Some(pipe) = self.pipe.as_mut() else {
+			return Poll::Ready(Err(closed()));
+		};
+		Pin::new(pipe).poll_flush(cx)
+	}
+
+	fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		let Some(pipe) = self.pipe.as_mut() else {
+			return Poll::Ready(Ok(()));
+		};
+		match Pin::new(pipe).poll_shutdown(cx) {
+			Poll::Ready(Ok(())) => {
+				self.pipe.take();
+				self.master.take();
+				Poll::Ready(Ok(()))
+			}
+			other => other,
+		}
+	}
+}
+
+#[derive(Debug)]
+pub(super) struct Output {
+	pipe: NamedPipeClient,
+	_master: SharedMaster,
+}
+
+impl AsyncRead for Output {
+	fn poll_read(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buffer: &mut ReadBuf<'_>,
+	) -> Poll<io::Result<()>> {
+		Pin::new(&mut self.pipe).poll_read(cx, buffer)
+	}
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Resize {
+	master: Weak<Master>,
+}
+
+impl Resize {
+	pub(super) fn resize(&self, size: PtySize) -> io::Result<()> {
+		let master = self.master.upgrade().ok_or_else(closed)?;
+		master.console.resize(size)
+	}
+}
+
+pub(super) fn controller(
+	console: PseudoConsole,
+	input: NamedPipeClient,
+	output: NamedPipeClient,
+) -> io::Result<(Input, Output, Resize)> {
+	let input_lifetime = duplicate(HANDLE(input.as_raw_handle()))?;
+	let output_lifetime = duplicate(HANDLE(output.as_raw_handle()))?;
+	let master = Arc::new(Master {
+		_input_lifetime: input_lifetime,
+		_output_lifetime: output_lifetime,
+		console,
+	});
+	let resize = Resize {
+		master: Arc::downgrade(&master),
+	};
+	let input = Input {
+		pipe: Some(input),
+		master: Some(Arc::clone(&master)),
+	};
+	let output = Output {
+		pipe: output,
+		_master: master,
+	};
+	Ok((input, output, resize))
+}
+
+fn duplicate(handle: HANDLE) -> io::Result<OwnedHandle> {
+	// SAFETY: the current-process pseudo-handle and source named-pipe handle are live, duplicate points
+	// to writable storage, and ownership of the non-inheritable result is transferred exactly once.
+	unsafe {
+		let process = GetCurrentProcess();
+		let mut duplicate = HANDLE::default();
+		DuplicateHandle(
+			process,
+			handle,
+			process,
+			&mut duplicate,
+			0,
+			false,
+			DUPLICATE_SAME_ACCESS,
+		)
+		.map_err(io::Error::other)?;
+		Ok(OwnedHandle::from_raw_handle(duplicate.0))
+	}
+}
+
+fn closed() -> io::Error {
+	io::Error::new(io::ErrorKind::BrokenPipe, "PTY master is closed")
+}

--- a/src/tokio/pty/windows/controller.rs
+++ b/src/tokio/pty/windows/controller.rs
@@ -29,7 +29,7 @@ struct Master {
 }
 
 #[derive(Debug)]
-pub(super) struct Input {
+pub(in crate::tokio::pty) struct Input {
 	pipe: Option<NamedPipeClient>,
 	master: Option<SharedMaster>,
 }
@@ -86,7 +86,7 @@ impl AsyncWrite for Input {
 }
 
 #[derive(Debug)]
-pub(super) struct Output {
+pub(in crate::tokio::pty) struct Output {
 	pipe: NamedPipeClient,
 	_master: SharedMaster,
 }
@@ -102,12 +102,12 @@ impl AsyncRead for Output {
 }
 
 #[derive(Clone, Debug)]
-pub(super) struct Resize {
+pub(in crate::tokio::pty) struct Resize {
 	master: Weak<Master>,
 }
 
 impl Resize {
-	pub(super) fn resize(&self, size: PtySize) -> io::Result<()> {
+	pub(in crate::tokio::pty) fn resize(&self, size: PtySize) -> io::Result<()> {
 		let master = self.master.upgrade().ok_or_else(closed)?;
 		master.console.resize(size)
 	}

--- a/src/tokio/pty/windows/environment.rs
+++ b/src/tokio/pty/windows/environment.rs
@@ -32,6 +32,7 @@ pub(super) enum PreparedEnvironment {
 }
 
 impl PreparedEnvironment {
+	#[cfg(test)]
 	pub(super) fn as_ptr(&self) -> *const u16 {
 		match self {
 			Self::Inherit => std::ptr::null(),
@@ -39,6 +40,7 @@ impl PreparedEnvironment {
 		}
 	}
 
+	#[cfg(test)]
 	pub(super) fn is_inherited(&self) -> bool {
 		matches!(self, Self::Inherit)
 	}

--- a/src/tokio/pty/windows/environment.rs
+++ b/src/tokio/pty/windows/environment.rs
@@ -137,7 +137,7 @@ fn set_variable(variables: &mut Vec<EnvironmentVariable>, variable: EnvironmentV
 	}
 }
 
-fn windows_equal(left: &[u16], right: &[u16]) -> bool {
+pub(super) fn windows_equal(left: &[u16], right: &[u16]) -> bool {
 	windows_compare(left, right) == Ordering::Equal
 }
 

--- a/src/tokio/pty/windows/mod.rs
+++ b/src/tokio/pty/windows/mod.rs
@@ -21,6 +21,7 @@ use command::{PreparedCommandLine, WideCString, prepare_command_line};
 use environment::{PreparedEnvironment, prepare_environment};
 
 mod api;
+mod attributes;
 pub(super) mod command;
 mod console;
 pub(super) mod environment;

--- a/src/tokio/pty/windows/mod.rs
+++ b/src/tokio/pty/windows/mod.rs
@@ -29,6 +29,7 @@ pub(super) mod command;
 mod console;
 pub(super) mod environment;
 mod pipe;
+mod program;
 
 #[derive(Debug, Eq, PartialEq)]
 struct PreparedWindowsCommand {
@@ -57,7 +58,9 @@ pub(super) fn try_resume_primary_thread(child: &mut dyn ChildWrapper) -> Option<
 }
 
 fn prepare(command: &PtyCommand) -> io::Result<PreparedWindowsCommand> {
-	prepare_with(command, prepare_environment)
+	let mut prepared = prepare_with(command, prepare_environment)?;
+	prepared.application_name = program::resolve(&command.intent)?;
+	Ok(prepared)
 }
 
 fn prepare_with(

--- a/src/tokio/pty/windows/mod.rs
+++ b/src/tokio/pty/windows/mod.rs
@@ -14,6 +14,8 @@ use super::super::CreationFlags;
 use super::super::JobObject;
 #[cfg(feature = "kill-on-drop")]
 use super::super::KillOnDrop;
+#[cfg(feature = "job-object")]
+use super::ChildWrapper;
 use super::{EnvironmentIntent, PtyCommand, WrapperRegistration};
 #[cfg(feature = "job-object")]
 use crate::windows::job_creation_flags;
@@ -45,6 +47,13 @@ struct WindowsCreationPolicy {
 	has_job_object: bool,
 	resume_after_assignment: bool,
 	kill_on_drop: bool,
+}
+
+#[cfg(feature = "job-object")]
+pub(super) fn try_resume_primary_thread(child: &mut dyn ChildWrapper) -> Option<io::Result<()>> {
+	child
+		.downcast_mut::<child::ConPtyChild>()
+		.map(child::ConPtyChild::resume_primary_thread)
 }
 
 fn prepare(command: &PtyCommand) -> io::Result<PreparedWindowsCommand> {

--- a/src/tokio/pty/windows/mod.rs
+++ b/src/tokio/pty/windows/mod.rs
@@ -23,6 +23,7 @@ use environment::{PreparedEnvironment, prepare_environment};
 mod api;
 pub(super) mod command;
 pub(super) mod environment;
+mod pipe;
 
 #[derive(Debug, Eq, PartialEq)]
 struct PreparedWindowsCommand {

--- a/src/tokio/pty/windows/mod.rs
+++ b/src/tokio/pty/windows/mod.rs
@@ -22,6 +22,7 @@ use environment::{PreparedEnvironment, prepare_environment};
 
 mod api;
 mod attributes;
+mod child;
 pub(super) mod command;
 mod console;
 pub(super) mod environment;

--- a/src/tokio/pty/windows/mod.rs
+++ b/src/tokio/pty/windows/mod.rs
@@ -30,6 +30,7 @@ mod console;
 pub(super) mod environment;
 mod pipe;
 mod program;
+mod spawn;
 
 #[derive(Debug, Eq, PartialEq)]
 struct PreparedWindowsCommand {

--- a/src/tokio/pty/windows/mod.rs
+++ b/src/tokio/pty/windows/mod.rs
@@ -22,6 +22,7 @@ use environment::{PreparedEnvironment, prepare_environment};
 
 mod api;
 pub(super) mod command;
+mod console;
 pub(super) mod environment;
 mod pipe;
 

--- a/src/tokio/pty/windows/mod.rs
+++ b/src/tokio/pty/windows/mod.rs
@@ -20,6 +20,7 @@ use crate::windows::job_creation_flags;
 use command::{PreparedCommandLine, WideCString, prepare_command_line};
 use environment::{PreparedEnvironment, prepare_environment};
 
+mod api;
 pub(super) mod command;
 pub(super) mod environment;
 

--- a/src/tokio/pty/windows/mod.rs
+++ b/src/tokio/pty/windows/mod.rs
@@ -24,6 +24,7 @@ use environment::{PreparedEnvironment, prepare_environment};
 
 mod api;
 mod attributes;
+mod backend;
 mod child;
 pub(super) mod command;
 mod console;
@@ -32,6 +33,9 @@ pub(super) mod environment;
 mod pipe;
 mod program;
 mod spawn;
+
+pub(super) use backend::spawn;
+pub(super) use controller::{Input, Output, Resize};
 
 #[derive(Debug, Eq, PartialEq)]
 struct PreparedWindowsCommand {

--- a/src/tokio/pty/windows/mod.rs
+++ b/src/tokio/pty/windows/mod.rs
@@ -27,6 +27,7 @@ mod attributes;
 mod child;
 pub(super) mod command;
 mod console;
+mod controller;
 pub(super) mod environment;
 mod pipe;
 mod program;

--- a/src/tokio/pty/windows/pipe.rs
+++ b/src/tokio/pty/windows/pipe.rs
@@ -1,0 +1,125 @@
+//! Split named pipes for the ConPTY-facing synchronous and host-facing overlapped endpoints.
+
+use std::{
+	ffi::OsString,
+	io,
+	os::windows::{
+		ffi::OsStrExt,
+		io::{AsRawHandle, FromRawHandle, OwnedHandle},
+	},
+	sync::atomic::{AtomicU64, Ordering},
+};
+
+use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
+use windows::{
+	Win32::{
+		Foundation::{HANDLE, INVALID_HANDLE_VALUE},
+		Storage::FileSystem::{
+			FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAGS_AND_ATTRIBUTES, PIPE_ACCESS_INBOUND,
+			PIPE_ACCESS_OUTBOUND,
+		},
+		System::Pipes::{
+			CreateNamedPipeW, NAMED_PIPE_MODE, PIPE_READMODE_BYTE, PIPE_REJECT_REMOTE_CLIENTS,
+			PIPE_TYPE_BYTE, PIPE_WAIT,
+		},
+	},
+	core::PCWSTR,
+};
+
+#[derive(Clone, Copy, Debug)]
+enum Direction {
+	Input,
+	Output,
+}
+
+impl Direction {
+	fn suffix(self) -> &'static str {
+		match self {
+			Self::Input => "in",
+			Self::Output => "out",
+		}
+	}
+
+	fn server_access(self) -> FILE_FLAGS_AND_ATTRIBUTES {
+		let access = match self {
+			Self::Input => PIPE_ACCESS_INBOUND,
+			Self::Output => PIPE_ACCESS_OUTBOUND,
+		};
+		access | FILE_FLAG_FIRST_PIPE_INSTANCE
+	}
+
+	fn configure_client(self, options: &mut ClientOptions) {
+		match self {
+			Self::Input => {
+				options.read(false).write(true);
+			}
+			Self::Output => {
+				options.read(true).write(false);
+			}
+		}
+	}
+}
+
+#[derive(Debug)]
+pub(super) struct PipePair {
+	server: OwnedHandle,
+	host: NamedPipeClient,
+}
+
+impl PipePair {
+	pub(super) fn input() -> io::Result<Self> {
+		Self::create(Direction::Input)
+	}
+
+	pub(super) fn output() -> io::Result<Self> {
+		Self::create(Direction::Output)
+	}
+
+	fn create(direction: Direction) -> io::Result<Self> {
+		static NEXT_PIPE: AtomicU64 = AtomicU64::new(0);
+
+		let sequence = NEXT_PIPE.fetch_add(1, Ordering::Relaxed);
+		let name = OsString::from(format!(
+			r"\\.\pipe\process-wrap-conpty-{}-{sequence}-{}",
+			std::process::id(),
+			direction.suffix()
+		));
+		let wide_name = name.encode_wide().chain([0]).collect::<Vec<_>>();
+		let pipe_mode: NAMED_PIPE_MODE =
+			PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS;
+
+		// SAFETY: wide_name is NUL-terminated and remains live for the call. Null security attributes
+		// produce a non-inheritable synchronous server handle, as required by ConPTY.
+		let server = unsafe {
+			CreateNamedPipeW(
+				PCWSTR(wide_name.as_ptr()),
+				direction.server_access(),
+				pipe_mode,
+				1,
+				0,
+				0,
+				0,
+				None,
+			)
+		};
+		if server == INVALID_HANDLE_VALUE {
+			return Err(io::Error::last_os_error());
+		}
+		// SAFETY: CreateNamedPipeW returned a unique owned handle which is transferred exactly once.
+		let server = unsafe { OwnedHandle::from_raw_handle(server.0) };
+
+		let mut options = ClientOptions::new();
+		direction.configure_client(&mut options);
+		let host = options.open(&name)?;
+
+		Ok(Self { server, host })
+	}
+
+	pub(super) fn server_handle(&self) -> HANDLE {
+		HANDLE(self.server.as_raw_handle())
+	}
+
+	pub(super) fn into_parts(self) -> (OwnedHandle, NamedPipeClient) {
+		(self.server, self.host)
+	}
+}

--- a/src/tokio/pty/windows/pipe.rs
+++ b/src/tokio/pty/windows/pipe.rs
@@ -123,3 +123,66 @@ impl PipePair {
 		(self.server, self.host)
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		fs::File,
+		io::{Read, Write},
+		os::windows::io::AsRawHandle,
+	};
+
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+	use windows::Win32::Foundation::{GetHandleInformation, HANDLE_FLAG_INHERIT};
+
+	use super::*;
+
+	fn assert_not_inheritable(handle: HANDLE) {
+		let mut flags = 0;
+		// SAFETY: handle is borrowed from a live owner and flags points to initialized writable storage.
+		unsafe { GetHandleInformation(handle, &mut flags) }.unwrap();
+		assert_eq!(flags & HANDLE_FLAG_INHERIT.0, 0);
+	}
+
+	#[tokio::test]
+	async fn input_pair_has_a_synchronous_reader_and_overlapped_writer() {
+		let pair = PipePair::input().unwrap();
+		assert_not_inheritable(pair.server_handle());
+		assert_not_inheritable(HANDLE(pair.host.as_raw_handle()));
+		let (server, mut host) = pair.into_parts();
+
+		let reader = std::thread::spawn(move || {
+			let mut server = File::from(server);
+			let mut bytes = [0; 4];
+			server.read_exact(&mut bytes).unwrap();
+			bytes
+		});
+		host.write_all(b"ping").await.unwrap();
+		host.shutdown().await.unwrap();
+		assert_eq!(reader.join().unwrap(), *b"ping");
+	}
+
+	#[tokio::test]
+	async fn output_pair_has_a_synchronous_writer_and_overlapped_reader() {
+		let pair = PipePair::output().unwrap();
+		assert_not_inheritable(pair.server_handle());
+		assert_not_inheritable(HANDLE(pair.host.as_raw_handle()));
+		let (server, mut host) = pair.into_parts();
+
+		let writer = std::thread::spawn(move || {
+			let mut server = File::from(server);
+			server.write_all(b"pong").unwrap();
+		});
+		let mut bytes = [0; 4];
+		host.read_exact(&mut bytes).await.unwrap();
+		writer.join().unwrap();
+		assert_eq!(bytes, *b"pong");
+	}
+
+	#[tokio::test]
+	async fn pipe_names_are_unique_across_live_pairs() {
+		let first = PipePair::input().unwrap();
+		let second = PipePair::input().unwrap();
+		assert_ne!(first.server.as_raw_handle(), second.server.as_raw_handle());
+	}
+}

--- a/src/tokio/pty/windows/program.rs
+++ b/src/tokio/pty/windows/program.rs
@@ -1,0 +1,167 @@
+//! Resolution of tracked program intent to the explicit `CreateProcessW` application name.
+
+use std::{
+	env,
+	ffi::{OsStr, OsString},
+	io,
+	os::windows::ffi::OsStringExt,
+	path::{Component, Path, PathBuf},
+};
+
+use windows::Win32::System::SystemInformation::{GetSystemDirectoryW, GetWindowsDirectoryW};
+
+use super::{
+	super::{CommandIntent, EnvChange},
+	command::{WideCString, encode},
+	environment::windows_equal,
+};
+
+pub(super) fn resolve(intent: &CommandIntent) -> io::Result<WideCString> {
+	let program = &intent.program;
+	let encoded = encode(program, "PTY program")?;
+	if has_suffix(&encoded, b".bat") || has_suffix(&encoded, b".cmd") {
+		return Err(io::Error::new(
+			io::ErrorKind::InvalidInput,
+			"Windows PTY spawning does not execute batch scripts directly",
+		));
+	}
+
+	let path = Path::new(program);
+	if program.is_empty() || path.file_name().is_none() {
+		return Err(io::Error::new(
+			io::ErrorKind::InvalidInput,
+			"PTY program path has no file name",
+		));
+	}
+
+	if !is_file_name(path, program) {
+		if has_suffix(&encoded, b".exe") {
+			return WideCString::from_os(program, "PTY program");
+		}
+		let with_exe = append_exe(path);
+		if with_exe.exists() {
+			return WideCString::from_os(with_exe.as_os_str(), "PTY program");
+		}
+		return WideCString::from_os(program, "PTY program");
+	}
+
+	let has_extension = encoded.contains(&(b'.' as u16));
+	let child_path = child_path(intent)?;
+	if let Some(path) = child_path.as_deref() {
+		if let Some(program) = search_path(path, program, has_extension) {
+			return WideCString::from_os(program.as_os_str(), "PTY program");
+		}
+	}
+	if let Ok(mut directory) = env::current_exe() {
+		directory.pop();
+		if let Some(program) = candidate(directory, program, has_extension) {
+			return WideCString::from_os(program.as_os_str(), "PTY program");
+		}
+	}
+	if let Ok(directory) = system_directory() {
+		if let Some(program) = candidate(directory, program, has_extension) {
+			return WideCString::from_os(program.as_os_str(), "PTY program");
+		}
+	}
+	if let Ok(directory) = windows_directory() {
+		if let Some(program) = candidate(directory, program, has_extension) {
+			return WideCString::from_os(program.as_os_str(), "PTY program");
+		}
+	}
+	if let Some(path) = env::var_os("PATH") {
+		if let Some(program) = search_path(&path, program, has_extension) {
+			return WideCString::from_os(program.as_os_str(), "PTY program");
+		}
+	}
+
+	Err(io::Error::new(
+		io::ErrorKind::NotFound,
+		"PTY program not found",
+	))
+}
+
+fn child_path(intent: &CommandIntent) -> io::Result<Option<OsString>> {
+	let path_key = "PATH".encode_utf16().collect::<Vec<_>>();
+	let mut child_path = None;
+	for change in &intent.environment.changes {
+		let key = match change {
+			EnvChange::Set(key, _) | EnvChange::Remove(key) => key,
+		};
+		if windows_equal(&encode(key, "PTY environment key")?, &path_key) {
+			child_path = match change {
+				EnvChange::Set(_, value) => Some(value.clone()),
+				EnvChange::Remove(_) => None,
+			};
+		}
+	}
+	Ok(child_path)
+}
+
+fn search_path(paths: &OsStr, program: &OsStr, has_extension: bool) -> Option<PathBuf> {
+	env::split_paths(paths)
+		.filter(|path| !path.as_os_str().is_empty())
+		.find_map(|path| candidate(path, program, has_extension))
+}
+
+fn candidate(mut directory: PathBuf, program: &OsStr, has_extension: bool) -> Option<PathBuf> {
+	directory.push(program);
+	if !has_extension {
+		directory = append_exe(&directory);
+	}
+	directory.exists().then_some(directory)
+}
+
+fn append_exe(path: &Path) -> PathBuf {
+	let mut path = path.as_os_str().to_os_string();
+	path.push(".exe");
+	PathBuf::from(path)
+}
+
+fn is_file_name(path: &Path, program: &OsStr) -> bool {
+	let mut components = path.components();
+	matches!(components.next(), Some(Component::Normal(name)) if name == program)
+		&& components.next().is_none()
+}
+
+fn has_suffix(value: &[u16], suffix: &[u8]) -> bool {
+	value.len() >= suffix.len()
+		&& value[value.len() - suffix.len()..]
+			.iter()
+			.zip(suffix)
+			.all(|(&left, &right)| {
+				u8::try_from(left).is_ok_and(|left| left.eq_ignore_ascii_case(&right))
+			})
+}
+
+fn system_directory() -> io::Result<PathBuf> {
+	query_directory(|buffer| {
+		// SAFETY: the optional slice is writable for its reported length.
+		unsafe { GetSystemDirectoryW(buffer) }
+	})
+}
+
+fn windows_directory() -> io::Result<PathBuf> {
+	query_directory(|buffer| {
+		// SAFETY: the optional slice is writable for its reported length.
+		unsafe { GetWindowsDirectoryW(buffer) }
+	})
+}
+
+fn query_directory(mut query: impl FnMut(Option<&mut [u16]>) -> u32) -> io::Result<PathBuf> {
+	let required = query(None);
+	if required == 0 {
+		return Err(io::Error::last_os_error());
+	}
+	let mut buffer = vec![0; required as usize];
+	loop {
+		let length = query(Some(&mut buffer));
+		if length == 0 {
+			return Err(io::Error::last_os_error());
+		}
+		if (length as usize) < buffer.len() {
+			buffer.truncate(length as usize);
+			return Ok(PathBuf::from(OsString::from_wide(&buffer)));
+		}
+		buffer.resize(length as usize + 1, 0);
+	}
+}

--- a/src/tokio/pty/windows/program.rs
+++ b/src/tokio/pty/windows/program.rs
@@ -165,3 +165,115 @@ fn query_directory(mut query: impl FnMut(Option<&mut [u16]>) -> u32) -> io::Resu
 		buffer.resize(length as usize + 1, 0);
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use std::{
+		fs::File,
+		os::windows::ffi::{OsStrExt, OsStringExt},
+	};
+
+	use tempfile::tempdir;
+
+	use super::*;
+	use crate::tokio::pty::EnvironmentIntent;
+
+	fn intent(program: impl Into<OsString>) -> CommandIntent {
+		CommandIntent {
+			program: program.into(),
+			args: Vec::new(),
+			environment: EnvironmentIntent {
+				clear: false,
+				changes: Vec::new(),
+			},
+			current_dir: None,
+		}
+	}
+
+	fn units(path: &OsStr) -> Vec<u16> {
+		path.encode_wide().chain([0]).collect()
+	}
+
+	#[test]
+	fn preserves_explicit_executable_paths_and_wtf16() {
+		let current = env::current_exe().unwrap();
+		let resolved = resolve(&intent(current.as_os_str())).unwrap();
+		assert_eq!(resolved.as_units(), units(current.as_os_str()));
+
+		let raw = OsString::from_wide(&[
+			b'C' as u16,
+			b':' as u16,
+			b'\\' as u16,
+			0xd800,
+			b'.' as u16,
+			b'e' as u16,
+			b'x' as u16,
+			b'e' as u16,
+		]);
+		let resolved = resolve(&intent(raw.clone())).unwrap();
+		assert_eq!(resolved.as_units(), units(&raw));
+	}
+
+	#[test]
+	fn searches_the_application_and_system_directories() {
+		let current = env::current_exe().unwrap();
+		let file_name = current.file_name().unwrap().to_os_string();
+		let resolved = resolve(&intent(file_name)).unwrap();
+		assert_eq!(resolved.as_units(), units(current.as_os_str()));
+
+		let command = resolve(&intent("cmd")).unwrap();
+		let command = PathBuf::from(OsString::from_wide(
+			&command.as_units()[..command.as_units().len() - 1],
+		));
+		assert!(command.exists());
+		assert!(
+			command
+				.file_name()
+				.unwrap()
+				.to_string_lossy()
+				.eq_ignore_ascii_case("cmd.exe")
+		);
+	}
+
+	#[test]
+	fn searches_the_explicit_child_path_case_insensitively() {
+		let directory = tempdir().unwrap();
+		let executable = directory.path().join("tracked.exe");
+		File::create(&executable).unwrap();
+		let mut intent = intent("tracked");
+		intent.environment.changes.push(EnvChange::Set(
+			OsString::from("Path"),
+			directory.path().as_os_str().to_os_string(),
+		));
+
+		let resolved = resolve(&intent).unwrap();
+		assert_eq!(resolved.as_units(), units(executable.as_os_str()));
+	}
+
+	#[test]
+	fn appends_exe_to_an_existing_direct_path() {
+		let directory = tempdir().unwrap();
+		let requested = directory.path().join("direct");
+		let executable = directory.path().join("direct.exe");
+		File::create(&executable).unwrap();
+
+		let resolved = resolve(&intent(requested.as_os_str())).unwrap();
+		assert_eq!(resolved.as_units(), units(executable.as_os_str()));
+	}
+
+	#[test]
+	fn rejects_batch_files_and_missing_bare_programs() {
+		for program in ["script.bat", "SCRIPT.CMD"] {
+			let error = resolve(&intent(program)).unwrap_err();
+			assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+			assert_eq!(
+				error.to_string(),
+				"Windows PTY spawning does not execute batch scripts directly"
+			);
+		}
+
+		let error = resolve(&intent("process-wrap-definitely-missing-program")).unwrap_err();
+		assert_eq!(error.kind(), io::ErrorKind::NotFound);
+		assert_eq!(error.to_string(), "PTY program not found");
+	}
+}

--- a/src/tokio/pty/windows/spawn.rs
+++ b/src/tokio/pty/windows/spawn.rs
@@ -13,28 +13,25 @@ use windows::{
 		System::Threading::{
 			CREATE_UNICODE_ENVIRONMENT, CreateProcessW, EXTENDED_STARTUPINFO_PRESENT,
 			GetCurrentProcess, GetProcessIdOfThread, INFINITE, OpenProcess, PROCESS_INFORMATION,
-			PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, STARTUPINFOEXW, TerminateProcess,
-			WaitForSingleObject,
+			PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+			TerminateProcess, WaitForSingleObject,
 		},
 	},
 	core::{PCWSTR, PWSTR},
 };
 
 use super::{
-	PreparedWindowsCommand, attributes::AttributeList, child::ConPtyChild, console::Release,
+	PreparedWindowsCommand, attributes::AttributeList, child::ConPtyChild,
 	environment::PreparedEnvironment,
 };
 
 pub(super) fn spawn(
 	mut command: PreparedWindowsCommand,
 	attributes: &AttributeList,
-	release: Release,
 	input_server: OwnedHandle,
 	output_server: OwnedHandle,
 ) -> io::Result<SpawnedChild> {
-	let mut startup = STARTUPINFOEXW::default();
-	startup.StartupInfo.cb = size_of::<STARTUPINFOEXW>() as u32;
-	startup.lpAttributeList = attributes.as_ptr();
+	let startup = startup_info(attributes);
 
 	let mut flags = command.creation.spawn_flags | EXTENDED_STARTUPINFO_PRESENT;
 	let environment = match &command.environment {
@@ -52,7 +49,9 @@ pub(super) fn spawn(
 
 	// SAFETY: every pointer references live, NUL-terminated or explicitly bounded storage for the
 	// duration of the call. The command line is uniquely mutable, the startup attribute list owns its
-	// aligned backing storage, no handles are inherited, and information is writable output storage.
+	// aligned backing storage, no handles are inherited, and STARTF_USESTDHANDLES with three null slots
+	// asks ConPTY to install its console handles. The process-information value is writable output
+	// storage.
 	let created = unsafe {
 		CreateProcessW(
 			PCWSTR(command.application_name.as_ptr()),
@@ -75,8 +74,19 @@ pub(super) fn spawn(
 
 	let handles = SpawnedProcess::new(information)?;
 	let cleanup = handles.cleanup()?;
-	let child = handles.into_child(command.creation.kill_on_drop, release)?;
+	let child = handles.into_child(command.creation.kill_on_drop);
 	Ok(SpawnedChild { child, cleanup })
+}
+
+fn startup_info(attributes: &AttributeList) -> STARTUPINFOEXW {
+	let mut startup = STARTUPINFOEXW::default();
+	startup.StartupInfo.cb = size_of::<STARTUPINFOEXW>() as u32;
+	startup.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+	startup.StartupInfo.hStdInput = HANDLE::default();
+	startup.StartupInfo.hStdOutput = HANDLE::default();
+	startup.StartupInfo.hStdError = HANDLE::default();
+	startup.lpAttributeList = attributes.as_ptr();
+	startup
 }
 
 pub(super) struct SpawnedChild {
@@ -138,7 +148,7 @@ impl SpawnedProcess {
 		})
 	}
 
-	fn into_child(mut self, kill_on_drop: bool, release: Release) -> io::Result<ConPtyChild> {
+	fn into_child(mut self, kill_on_drop: bool) -> ConPtyChild {
 		let process = self
 			.process
 			.take()
@@ -147,7 +157,7 @@ impl SpawnedProcess {
 			.primary_thread
 			.take()
 			.expect("a spawned process guard must own its primary-thread handle");
-		ConPtyChild::new(process, primary_thread, self.pid, kill_on_drop, release)
+		ConPtyChild::new(process, primary_thread, self.pid, kill_on_drop)
 	}
 }
 
@@ -223,4 +233,21 @@ fn win32_io_error(error: windows::core::Error) -> io::Error {
 	WIN32_ERROR::from_error(&error)
 		.and_then(|error| i32::try_from(error.0).ok())
 		.map_or_else(|| io::Error::other(error), io::Error::from_raw_os_error)
+}
+
+#[cfg(test)]
+mod tests {
+	use windows::Win32::System::Console::HPCON;
+
+	use super::*;
+
+	#[test]
+	fn requests_conpty_replacement_for_all_standard_handles() {
+		let attributes = AttributeList::new(HPCON(42)).unwrap();
+		let startup = startup_info(&attributes);
+		assert_eq!(startup.StartupInfo.dwFlags, STARTF_USESTDHANDLES);
+		assert_eq!(startup.StartupInfo.hStdInput, HANDLE::default());
+		assert_eq!(startup.StartupInfo.hStdOutput, HANDLE::default());
+		assert_eq!(startup.StartupInfo.hStdError, HANDLE::default());
+	}
 }

--- a/src/tokio/pty/windows/spawn.rs
+++ b/src/tokio/pty/windows/spawn.rs
@@ -1,0 +1,219 @@
+//! Exact `CreateProcessW` spawning for a prepared ConPTY command.
+
+use std::{
+	ffi::c_void,
+	io,
+	mem::size_of,
+	os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle},
+};
+
+use windows::{
+	Win32::{
+		Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE, WIN32_ERROR},
+		System::Threading::{
+			CREATE_UNICODE_ENVIRONMENT, CreateProcessW, EXTENDED_STARTUPINFO_PRESENT,
+			GetCurrentProcess, GetProcessIdOfThread, INFINITE, OpenProcess, PROCESS_INFORMATION,
+			PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, STARTUPINFOEXW, TerminateProcess,
+			WaitForSingleObject,
+		},
+	},
+	core::{PCWSTR, PWSTR},
+};
+
+use super::{
+	PreparedWindowsCommand, attributes::AttributeList, child::ConPtyChild,
+	environment::PreparedEnvironment,
+};
+
+pub(super) fn spawn(
+	mut command: PreparedWindowsCommand,
+	attributes: &AttributeList,
+) -> io::Result<SpawnedChild> {
+	let mut startup = STARTUPINFOEXW::default();
+	startup.StartupInfo.cb = size_of::<STARTUPINFOEXW>() as u32;
+	startup.lpAttributeList = attributes.as_ptr();
+
+	let mut flags = command.creation.spawn_flags | EXTENDED_STARTUPINFO_PRESENT;
+	let environment = match &command.environment {
+		PreparedEnvironment::Inherit => None,
+		PreparedEnvironment::Block(block) => {
+			flags |= CREATE_UNICODE_ENVIRONMENT;
+			Some(block.as_ptr().cast::<c_void>())
+		}
+	};
+	let current_dir = command
+		.current_dir
+		.as_ref()
+		.map_or(PCWSTR::null(), |directory| PCWSTR(directory.as_ptr()));
+	let mut information = PROCESS_INFORMATION::default();
+
+	// SAFETY: every pointer references live, NUL-terminated or explicitly bounded storage for the
+	// duration of the call. The command line is uniquely mutable, the startup attribute list owns its
+	// aligned backing storage, no handles are inherited, and information is writable output storage.
+	unsafe {
+		CreateProcessW(
+			PCWSTR(command.application_name.as_ptr()),
+			Some(PWSTR(command.command_line.as_mut_ptr())),
+			None,
+			None,
+			false,
+			flags,
+			environment,
+			current_dir,
+			&startup.StartupInfo,
+			&mut information,
+		)
+	}
+	.map_err(win32_io_error)?;
+
+	let handles = SpawnedProcess::new(information)?;
+	let cleanup = handles.cleanup()?;
+	let child = handles.into_child(command.creation.kill_on_drop);
+	Ok(SpawnedChild { child, cleanup })
+}
+
+pub(super) struct SpawnedChild {
+	pub(super) child: ConPtyChild,
+	pub(super) cleanup: SpawnCleanup,
+}
+
+pub(super) struct SpawnCleanup {
+	process: Option<OwnedHandle>,
+}
+
+impl SpawnCleanup {
+	pub(super) fn disarm(mut self) {
+		self.process.take();
+	}
+}
+
+impl Drop for SpawnCleanup {
+	fn drop(&mut self) {
+		if let Some(process) = &self.process {
+			terminate_and_wait(process);
+		}
+	}
+}
+
+struct SpawnedProcess {
+	process: Option<OwnedHandle>,
+	primary_thread: Option<OwnedHandle>,
+	pid: u32,
+}
+
+impl SpawnedProcess {
+	fn new(information: PROCESS_INFORMATION) -> io::Result<Self> {
+		if information.hProcess.is_invalid() || information.hThread.is_invalid() {
+			cleanup_invalid_information(information);
+			return Err(io::Error::other(
+				"CreateProcessW returned invalid process information",
+			));
+		}
+
+		// SAFETY: CreateProcessW returned two distinct owned handles, each transferred exactly once.
+		let process = unsafe { OwnedHandle::from_raw_handle(information.hProcess.0) };
+		// SAFETY: as above, ownership of the primary-thread handle is transferred exactly once.
+		let primary_thread = unsafe { OwnedHandle::from_raw_handle(information.hThread.0) };
+		Ok(Self {
+			process: Some(process),
+			primary_thread: Some(primary_thread),
+			pid: information.dwProcessId,
+		})
+	}
+
+	fn cleanup(&self) -> io::Result<SpawnCleanup> {
+		let process = self
+			.process
+			.as_ref()
+			.expect("a spawned process guard must own its process handle");
+		Ok(SpawnCleanup {
+			process: Some(duplicate(process)?),
+		})
+	}
+
+	fn into_child(mut self, kill_on_drop: bool) -> ConPtyChild {
+		let process = self
+			.process
+			.take()
+			.expect("a spawned process guard must own its process handle");
+		let primary_thread = self
+			.primary_thread
+			.take()
+			.expect("a spawned process guard must own its primary-thread handle");
+		ConPtyChild::new(process, primary_thread, self.pid, kill_on_drop)
+	}
+}
+
+impl Drop for SpawnedProcess {
+	fn drop(&mut self) {
+		if let Some(process) = &self.process {
+			terminate_and_wait(process);
+		}
+	}
+}
+
+fn cleanup_invalid_information(information: PROCESS_INFORMATION) {
+	let thread = (!information.hThread.is_invalid()).then(|| {
+		// SAFETY: a non-invalid CreateProcessW output handle is uniquely owned here.
+		unsafe { OwnedHandle::from_raw_handle(information.hThread.0) }
+	});
+	let pid = thread.as_ref().map_or(0, |thread| {
+		// SAFETY: thread owns the live primary-thread handle returned by CreateProcessW.
+		unsafe { GetProcessIdOfThread(HANDLE(thread.as_raw_handle())) }
+	});
+	let pid = if pid != 0 && (information.dwProcessId == 0 || information.dwProcessId == pid) {
+		pid
+	} else {
+		0
+	};
+	let process = if !information.hProcess.is_invalid() {
+		// SAFETY: a non-invalid CreateProcessW output handle is uniquely owned here.
+		Some(unsafe { OwnedHandle::from_raw_handle(information.hProcess.0) })
+	} else if pid != 0 {
+		// SAFETY: pid identifies the process CreateProcessW reported creating. The recovered handle is
+		// non-inheritable and is transferred exactly once if it can still be opened.
+		unsafe { OpenProcess(PROCESS_TERMINATE | PROCESS_SYNCHRONIZE, false, pid) }
+			.ok()
+			.map(|handle| unsafe { OwnedHandle::from_raw_handle(handle.0) })
+	} else {
+		None
+	};
+	if let Some(process) = process {
+		terminate_and_wait(&process);
+	}
+}
+
+fn duplicate(handle: &OwnedHandle) -> io::Result<OwnedHandle> {
+	// SAFETY: the current-process pseudo-handle and source process handle are live, duplicate points
+	// to writable storage, and ownership of the non-inheritable result is transferred exactly once.
+	unsafe {
+		let current = GetCurrentProcess();
+		let mut duplicate = HANDLE::default();
+		DuplicateHandle(
+			current,
+			HANDLE(handle.as_raw_handle()),
+			current,
+			&mut duplicate,
+			0,
+			false,
+			DUPLICATE_SAME_ACCESS,
+		)
+		.map_err(win32_io_error)?;
+		Ok(OwnedHandle::from_raw_handle(duplicate.0))
+	}
+}
+
+fn terminate_and_wait(process: &OwnedHandle) {
+	let process = HANDLE(process.as_raw_handle());
+	// SAFETY: the guard owns the process handle and is cleaning up a process which cannot be returned
+	// to the caller. Waiting after termination prevents a detached live process.
+	let _ = unsafe { TerminateProcess(process, 1) };
+	// SAFETY: the process handle owner remains live until after this wait.
+	let _ = unsafe { WaitForSingleObject(process, INFINITE) };
+}
+
+fn win32_io_error(error: windows::core::Error) -> io::Error {
+	WIN32_ERROR::from_error(&error)
+		.and_then(|error| i32::try_from(error.0).ok())
+		.map_or_else(|| io::Error::other(error), io::Error::from_raw_os_error)
+}

--- a/src/tokio/pty/windows/spawn.rs
+++ b/src/tokio/pty/windows/spawn.rs
@@ -21,13 +21,14 @@ use windows::{
 };
 
 use super::{
-	PreparedWindowsCommand, attributes::AttributeList, child::ConPtyChild,
+	PreparedWindowsCommand, attributes::AttributeList, child::ConPtyChild, console::Release,
 	environment::PreparedEnvironment,
 };
 
 pub(super) fn spawn(
 	mut command: PreparedWindowsCommand,
 	attributes: &AttributeList,
+	release: Release,
 	input_server: OwnedHandle,
 	output_server: OwnedHandle,
 ) -> io::Result<SpawnedChild> {
@@ -74,7 +75,7 @@ pub(super) fn spawn(
 
 	let handles = SpawnedProcess::new(information)?;
 	let cleanup = handles.cleanup()?;
-	let child = handles.into_child(command.creation.kill_on_drop);
+	let child = handles.into_child(command.creation.kill_on_drop, release)?;
 	Ok(SpawnedChild { child, cleanup })
 }
 
@@ -137,7 +138,7 @@ impl SpawnedProcess {
 		})
 	}
 
-	fn into_child(mut self, kill_on_drop: bool) -> ConPtyChild {
+	fn into_child(mut self, kill_on_drop: bool, release: Release) -> io::Result<ConPtyChild> {
 		let process = self
 			.process
 			.take()
@@ -146,7 +147,7 @@ impl SpawnedProcess {
 			.primary_thread
 			.take()
 			.expect("a spawned process guard must own its primary-thread handle");
-		ConPtyChild::new(process, primary_thread, self.pid, kill_on_drop)
+		ConPtyChild::new(process, primary_thread, self.pid, kill_on_drop, release)
 	}
 }
 

--- a/src/tokio/pty/windows/spawn.rs
+++ b/src/tokio/pty/windows/spawn.rs
@@ -28,6 +28,8 @@ use super::{
 pub(super) fn spawn(
 	mut command: PreparedWindowsCommand,
 	attributes: &AttributeList,
+	input_server: OwnedHandle,
+	output_server: OwnedHandle,
 ) -> io::Result<SpawnedChild> {
 	let mut startup = STARTUPINFOEXW::default();
 	startup.StartupInfo.cb = size_of::<STARTUPINFOEXW>() as u32;
@@ -50,7 +52,7 @@ pub(super) fn spawn(
 	// SAFETY: every pointer references live, NUL-terminated or explicitly bounded storage for the
 	// duration of the call. The command line is uniquely mutable, the startup attribute list owns its
 	// aligned backing storage, no handles are inherited, and information is writable output storage.
-	unsafe {
+	let created = unsafe {
 		CreateProcessW(
 			PCWSTR(command.application_name.as_ptr()),
 			Some(PWSTR(command.command_line.as_mut_ptr())),
@@ -63,8 +65,12 @@ pub(super) fn spawn(
 			&startup.StartupInfo,
 			&mut information,
 		)
-	}
-	.map_err(win32_io_error)?;
+	};
+	// ConPTY retains these synchronous endpoints internally. Dropping the parent copies before any
+	// validation or handle duplication lets both host-facing channels observe closure on every path.
+	drop(input_server);
+	drop(output_server);
+	created.map_err(win32_io_error)?;
 
 	let handles = SpawnedProcess::new(information)?;
 	let cleanup = handles.cleanup()?;

--- a/tests/std_unix/mod.rs
+++ b/tests/std_unix/mod.rs
@@ -1,6 +1,11 @@
 mod prelude {
+	#[cfg(all(
+		target_os = "linux",
+		any(feature = "process-group", feature = "process-session")
+	))]
+	pub use std::io::{BufRead, BufReader};
 	pub use std::{
-		io::{BufRead, BufReader, Read, Result, Write},
+		io::{Read, Result, Write},
 		os::unix::process::ExitStatusExt,
 		process::Stdio,
 		thread::sleep,
@@ -12,6 +17,10 @@ mod prelude {
 
 	pub const DIE_TIME: Duration = Duration::from_millis(100);
 
+	#[cfg(all(
+		target_os = "linux",
+		any(feature = "process-group", feature = "process-session")
+	))]
 	#[track_caller]
 	pub fn pid_alive(pid: i32) -> bool {
 		#[inline]

--- a/tests/std_unix/multiproc_linux.rs
+++ b/tests/std_unix/multiproc_linux.rs
@@ -1,4 +1,7 @@
-#![cfg(target_os = "linux")]
+#![cfg(all(
+	target_os = "linux",
+	any(feature = "process-group", feature = "process-session")
+))]
 
 use super::prelude::*;
 

--- a/tests/tokio_pty_unsupported.rs
+++ b/tests/tokio_pty_unsupported.rs
@@ -1,6 +1,7 @@
 #![cfg(all(
 	feature = "pty",
 	not(any(
+		windows,
 		target_os = "android",
 		target_os = "dragonfly",
 		target_os = "freebsd",

--- a/tests/tokio_pty_windows.rs
+++ b/tests/tokio_pty_windows.rs
@@ -6,6 +6,12 @@ use std::{
 	time::Duration,
 };
 
+#[cfg(feature = "creation-flags")]
+use process_wrap::tokio::CreationFlags;
+#[cfg(feature = "job-object")]
+use process_wrap::tokio::JobObject;
+#[cfg(feature = "kill-on-drop")]
+use process_wrap::tokio::KillOnDrop;
 use process_wrap::tokio::{CommandWrap, CommandWrapper, PtyCommand, PtyOptions, PtySize};
 use tokio::{
 	io::{AsyncReadExt, AsyncWriteExt},
@@ -80,6 +86,9 @@ fn conpty_child_helper() -> io::Result<()> {
 
 	match mode.as_str() {
 		"terminal" => {
+			if let Some(path) = env::var_os("PW_TOUCH") {
+				std::fs::File::create(path)?;
+			}
 			print!(
 				"PW-TERMINALS:{}{}{}:{}:REMOVED={}:CWD={}",
 				is_console(stdin_handle) as u8,
@@ -324,6 +333,158 @@ async fn accepts_ordered_raw_argument_fragments() -> io::Result<()> {
 			.windows(16)
 			.any(|window| window == b"PW-TERMINALS:111")
 	);
+	Ok(())
+}
+
+#[cfg(feature = "creation-flags")]
+#[tokio::test]
+async fn creation_flags_compose_without_a_job_object() -> io::Result<()> {
+	use windows::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP;
+
+	let mut command = helper("terminal")?;
+	command.wrap(CreationFlags(CREATE_NEW_PROCESS_GROUP));
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	assert!(timeout(TIMEOUT, child.wait()).await??.success());
+	let mut bytes = Vec::new();
+	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		bytes
+			.windows(16)
+			.any(|window| window == b"PW-TERMINALS:111")
+	);
+	Ok(())
+}
+
+#[cfg(feature = "job-object")]
+#[tokio::test]
+async fn job_object_resumes_its_temporarily_suspended_primary_thread() -> io::Result<()> {
+	let mut command = helper("terminal")?;
+	command.wrap(JobObject);
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	assert!(timeout(TIMEOUT, child.wait()).await??.success());
+	let mut bytes = Vec::new();
+	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		bytes
+			.windows(16)
+			.any(|window| window == b"PW-TERMINALS:111")
+	);
+	Ok(())
+}
+
+#[cfg(all(feature = "creation-flags", feature = "job-object"))]
+#[tokio::test]
+async fn job_object_composes_with_creation_flags_in_both_orders() -> io::Result<()> {
+	use windows::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP;
+
+	for reverse in [false, true] {
+		let mut command = helper("terminal")?;
+		if reverse {
+			command
+				.wrap(JobObject)
+				.wrap(CreationFlags(CREATE_NEW_PROCESS_GROUP));
+		} else {
+			command
+				.wrap(CreationFlags(CREATE_NEW_PROCESS_GROUP))
+				.wrap(JobObject);
+		}
+		let (mut child, controller) = command.spawn(PtyOptions::default())?;
+		let (input, mut output, _resize) = controller.into_parts();
+		drop(input);
+		assert!(timeout(TIMEOUT, child.wait()).await??.success());
+		let mut bytes = Vec::new();
+		timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+		assert!(
+			bytes
+				.windows(16)
+				.any(|window| window == b"PW-TERMINALS:111")
+		);
+	}
+	Ok(())
+}
+
+#[cfg(all(feature = "creation-flags", feature = "job-object"))]
+#[tokio::test]
+async fn job_object_preserves_explicit_suspension() -> io::Result<()> {
+	use windows::Win32::System::Threading::CREATE_SUSPENDED;
+
+	let directory = tempfile::tempdir()?;
+	let touched = directory.path().join("resumed");
+	let mut command = helper("terminal")?;
+	command
+		.env("PW_TOUCH", &touched)
+		.wrap(CreationFlags(CREATE_SUSPENDED))
+		.wrap(JobObject);
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	tokio::time::sleep(Duration::from_millis(500)).await;
+	assert!(
+		!touched.exists(),
+		"an explicitly suspended ConPTY child started running"
+	);
+	child.start_kill()?;
+	timeout(TIMEOUT, child.wait()).await??;
+	drop(input);
+	let mut bytes = Vec::new();
+	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		!bytes
+			.windows(16)
+			.any(|window| window == b"PW-TERMINALS:111")
+	);
+	Ok(())
+}
+
+#[cfg(feature = "kill-on-drop")]
+async fn assert_killed_on_drop(mut command: PtyCommand) -> io::Result<()> {
+	use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+	use windows::Win32::{
+		Foundation::WAIT_OBJECT_0,
+		System::Threading::{OpenProcess, PROCESS_SYNCHRONIZE, WaitForSingleObject},
+	};
+
+	let (child, controller) = command.spawn(PtyOptions::default())?;
+	let pid = child.id().expect("ConPTY children expose a process ID");
+	let (_input, mut output, _resize) = controller.into_parts();
+	read_through(&mut output, b"PW-READY").await?;
+	// SAFETY: pid identifies the live child. Ownership of the non-inheritable handle is transferred.
+	let process =
+		unsafe { OpenProcess(PROCESS_SYNCHRONIZE, false, pid) }.map_err(io::Error::other)?;
+	// SAFETY: OpenProcess returned a unique owned handle.
+	let process = unsafe { OwnedHandle::from_raw_handle(process.0) };
+	drop(child);
+	let wait = tokio::task::spawn_blocking(move || {
+		// SAFETY: process owns the live synchronization handle for this wait.
+		unsafe { WaitForSingleObject(HANDLE(process.as_raw_handle()), 10_000) }
+	});
+	assert_eq!(wait.await.map_err(io::Error::other)?, WAIT_OBJECT_0);
+	Ok(())
+}
+
+#[cfg(feature = "kill-on-drop")]
+#[tokio::test]
+async fn kill_on_drop_terminates_a_conpty_child() -> io::Result<()> {
+	let mut command = helper("wait")?;
+	command.wrap(KillOnDrop);
+	assert_killed_on_drop(command).await
+}
+
+#[cfg(all(feature = "job-object", feature = "kill-on-drop"))]
+#[tokio::test]
+async fn job_object_composes_with_kill_on_drop_in_both_orders() -> io::Result<()> {
+	for reverse in [false, true] {
+		let mut command = helper("wait")?;
+		if reverse {
+			command.wrap(JobObject).wrap(KillOnDrop);
+		} else {
+			command.wrap(KillOnDrop).wrap(JobObject);
+		}
+		assert_killed_on_drop(command).await?;
+	}
 	Ok(())
 }
 

--- a/tests/tokio_pty_windows.rs
+++ b/tests/tokio_pty_windows.rs
@@ -146,9 +146,12 @@ fn conpty_child_helper() -> io::Result<()> {
 			io::stdout().flush()?;
 			let mut bytes = [0; 4];
 			io::stdin().read_exact(&mut bytes)?;
-			io::stdout().write_all(b"PW-BYTES:")?;
-			io::stdout().write_all(&bytes)?;
-			io::stdout().flush()?;
+			let mut stdout = io::stdout();
+			stdout.write_all(b"PW-BYTES:")?;
+			for byte in bytes {
+				write!(stdout, "{byte:02x}")?;
+			}
+			stdout.flush()?;
 		}
 		"size" => {
 			print_size(stdout_handle)?;
@@ -289,12 +292,11 @@ async fn passes_bidirectional_terminal_bytes() -> io::Result<()> {
 			.await?
 			.success()
 	);
-	let mut expected = b"PW-BYTES:".to_vec();
-	expected.extend(controls);
+	let expected = b"PW-BYTES:411b4243";
 	assert!(
 		bytes
 			.windows(expected.len())
-			.any(|window| window == expected.as_slice()),
+			.any(|window| window == expected),
 		"{:?}",
 		bytes
 	);

--- a/tests/tokio_pty_windows.rs
+++ b/tests/tokio_pty_windows.rs
@@ -4,6 +4,7 @@ use std::{
 	env,
 	io::{self, Read, Write},
 	path::{Path, PathBuf},
+	process::ExitStatus,
 	time::Duration,
 };
 
@@ -13,7 +14,9 @@ use process_wrap::tokio::CreationFlags;
 use process_wrap::tokio::JobObject;
 #[cfg(feature = "kill-on-drop")]
 use process_wrap::tokio::KillOnDrop;
-use process_wrap::tokio::{CommandWrap, CommandWrapper, PtyCommand, PtyOptions, PtySize};
+use process_wrap::tokio::{
+	ChildWrapper, CommandWrap, CommandWrapper, PtyCommand, PtyOptions, PtyOutput, PtySize,
+};
 use tokio::{
 	io::{AsyncReadExt, AsyncWriteExt},
 	time::timeout,
@@ -59,10 +62,7 @@ impl Drop for ReleaseOnDrop {
 	}
 }
 
-async fn read_through(
-	output: &mut process_wrap::tokio::PtyOutput,
-	needle: &[u8],
-) -> io::Result<Vec<u8>> {
+async fn read_through(output: &mut PtyOutput, needle: &[u8]) -> io::Result<Vec<u8>> {
 	timeout(TIMEOUT, async {
 		let mut bytes = Vec::new();
 		let mut buffer = [0; 1024];
@@ -80,6 +80,19 @@ async fn read_through(
 	})
 	.await
 	.map_err(io::Error::other)?
+}
+
+async fn wait_and_drain(
+	child: &mut dyn ChildWrapper,
+	output: &mut PtyOutput,
+	bytes: &mut Vec<u8>,
+) -> io::Result<ExitStatus> {
+	let (status, _) = timeout(TIMEOUT, async {
+		tokio::try_join!(child.wait(), output.read_to_end(bytes))
+	})
+	.await
+	.map_err(io::Error::other)??;
+	Ok(status)
 }
 
 fn terminal_handles() -> io::Result<(HANDLE, HANDLE, HANDLE)> {
@@ -206,8 +219,11 @@ async fn attaches_standard_handles_before_releasing_console_ownership() -> io::R
 	drop(input);
 
 	let mut bytes = read_through(&mut output, b"PW-TERMINALS:111").await?;
-	assert!(timeout(TIMEOUT, child.wait()).await??.success());
-	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		wait_and_drain(child.as_mut(), &mut output, &mut bytes)
+			.await?
+			.success()
+	);
 	Ok(())
 }
 
@@ -230,9 +246,12 @@ async fn exposes_terminal_handles_and_preserves_environment_cwd_and_merged_outpu
 	let (mut child, controller) = command.spawn(PtyOptions::default())?;
 	let (input, mut output, _resize) = controller.into_parts();
 	drop(input);
-	assert!(timeout(TIMEOUT, child.wait()).await??.success());
 	let mut bytes = Vec::new();
-	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		wait_and_drain(child.as_mut(), &mut output, &mut bytes)
+			.await?
+			.success()
+	);
 	let marker = format!(
 		"PW-TERMINALS:111:child-value:REMOVED=1:CWD={}",
 		directory.path().display()
@@ -264,8 +283,11 @@ async fn passes_bidirectional_terminal_bytes() -> io::Result<()> {
 	let controls = [b'A', 0x1b, b'B', b'C'];
 	input.write_all(&controls).await?;
 	input.shutdown().await?;
-	assert!(timeout(TIMEOUT, child.wait()).await??.success());
-	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		wait_and_drain(child.as_mut(), &mut output, &mut bytes)
+			.await?
+			.success()
+	);
 	let mut expected = b"PW-BYTES:".to_vec();
 	expected.extend(controls);
 	assert!(
@@ -392,9 +414,12 @@ async fn failed_spawn_leaves_the_tracked_command_reusable() -> io::Result<()> {
 	let (mut child, controller) = command.spawn(PtyOptions::default())?;
 	let (input, mut output, _resize) = controller.into_parts();
 	drop(input);
-	assert!(timeout(TIMEOUT, child.wait()).await??.success());
 	let mut bytes = Vec::new();
-	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		wait_and_drain(child.as_mut(), &mut output, &mut bytes)
+			.await?
+			.success()
+	);
 	assert!(
 		bytes
 			.windows(16)
@@ -414,9 +439,12 @@ async fn accepts_ordered_raw_argument_fragments() -> io::Result<()> {
 	let (mut child, controller) = command.spawn(PtyOptions::default())?;
 	let (input, mut output, _resize) = controller.into_parts();
 	drop(input);
-	assert!(timeout(TIMEOUT, child.wait()).await??.success());
 	let mut bytes = Vec::new();
-	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		wait_and_drain(child.as_mut(), &mut output, &mut bytes)
+			.await?
+			.success()
+	);
 	assert!(
 		bytes
 			.windows(16)
@@ -435,9 +463,12 @@ async fn creation_flags_compose_without_a_job_object() -> io::Result<()> {
 	let (mut child, controller) = command.spawn(PtyOptions::default())?;
 	let (input, mut output, _resize) = controller.into_parts();
 	drop(input);
-	assert!(timeout(TIMEOUT, child.wait()).await??.success());
 	let mut bytes = Vec::new();
-	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		wait_and_drain(child.as_mut(), &mut output, &mut bytes)
+			.await?
+			.success()
+	);
 	assert!(
 		bytes
 			.windows(16)
@@ -454,9 +485,12 @@ async fn job_object_resumes_its_temporarily_suspended_primary_thread() -> io::Re
 	let (mut child, controller) = command.spawn(PtyOptions::default())?;
 	let (input, mut output, _resize) = controller.into_parts();
 	drop(input);
-	assert!(timeout(TIMEOUT, child.wait()).await??.success());
 	let mut bytes = Vec::new();
-	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		wait_and_drain(child.as_mut(), &mut output, &mut bytes)
+			.await?
+			.success()
+	);
 	assert!(
 		bytes
 			.windows(16)
@@ -484,9 +518,12 @@ async fn job_object_composes_with_creation_flags_in_both_orders() -> io::Result<
 		let (mut child, controller) = command.spawn(PtyOptions::default())?;
 		let (input, mut output, _resize) = controller.into_parts();
 		drop(input);
-		assert!(timeout(TIMEOUT, child.wait()).await??.success());
 		let mut bytes = Vec::new();
-		timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+		assert!(
+			wait_and_drain(child.as_mut(), &mut output, &mut bytes)
+				.await?
+				.success()
+		);
 		assert!(
 			bytes
 				.windows(16)

--- a/tests/tokio_pty_windows.rs
+++ b/tests/tokio_pty_windows.rs
@@ -199,6 +199,19 @@ fn print_size(output: HANDLE) -> io::Result<()> {
 }
 
 #[tokio::test]
+async fn attaches_standard_handles_before_releasing_console_ownership() -> io::Result<()> {
+	let mut command = helper("terminal")?;
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+
+	let mut bytes = read_through(&mut output, b"PW-TERMINALS:111").await?;
+	assert!(timeout(TIMEOUT, child.wait()).await??.success());
+	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	Ok(())
+}
+
+#[tokio::test]
 async fn exposes_terminal_handles_and_preserves_environment_cwd_and_merged_output() -> io::Result<()>
 {
 	let directory = tempfile::tempdir()?;

--- a/tests/tokio_pty_windows.rs
+++ b/tests/tokio_pty_windows.rs
@@ -1,0 +1,351 @@
+#![cfg(all(windows, feature = "pty"))]
+
+use std::{
+	env,
+	io::{self, Read, Write},
+	time::Duration,
+};
+
+use process_wrap::tokio::{CommandWrap, CommandWrapper, PtyCommand, PtyOptions, PtySize};
+use tokio::{
+	io::{AsyncReadExt, AsyncWriteExt},
+	time::timeout,
+};
+use windows::Win32::{
+	Foundation::HANDLE,
+	System::Console::{
+		ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT, GetConsoleMode,
+		GetConsoleScreenBufferInfo, GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE,
+		STD_OUTPUT_HANDLE, SetConsoleMode,
+	},
+};
+
+const HELPER_MODE: &str = "PROCESS_WRAP_CONPTY_HELPER";
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+fn helper(mode: &str) -> io::Result<PtyCommand> {
+	let mut command = PtyCommand::new(env::current_exe()?);
+	command
+		.args(["--exact", "conpty_child_helper", "--nocapture"])
+		.env(HELPER_MODE, mode);
+	Ok(command)
+}
+
+async fn read_through(
+	output: &mut process_wrap::tokio::PtyOutput,
+	needle: &[u8],
+) -> io::Result<Vec<u8>> {
+	timeout(TIMEOUT, async {
+		let mut bytes = Vec::new();
+		let mut buffer = [0; 1024];
+		while !bytes.windows(needle.len()).any(|window| window == needle) {
+			let read = output.read(&mut buffer).await?;
+			if read == 0 {
+				return Err(io::Error::new(
+					io::ErrorKind::UnexpectedEof,
+					"ConPTY output closed before the expected marker",
+				));
+			}
+			bytes.extend_from_slice(&buffer[..read]);
+		}
+		Ok(bytes)
+	})
+	.await
+	.map_err(io::Error::other)?
+}
+
+fn terminal_handles() -> io::Result<(HANDLE, HANDLE, HANDLE)> {
+	// SAFETY: these calls only retrieve this process's standard handles.
+	unsafe {
+		Ok((
+			GetStdHandle(STD_INPUT_HANDLE).map_err(io::Error::other)?,
+			GetStdHandle(STD_OUTPUT_HANDLE).map_err(io::Error::other)?,
+			GetStdHandle(STD_ERROR_HANDLE).map_err(io::Error::other)?,
+		))
+	}
+}
+
+fn is_console(handle: HANDLE) -> bool {
+	let mut mode = Default::default();
+	// SAFETY: handle is borrowed from a live standard handle and mode is writable storage.
+	unsafe { GetConsoleMode(handle, &mut mode) }.is_ok()
+}
+
+#[test]
+fn conpty_child_helper() -> io::Result<()> {
+	let Ok(mode) = env::var(HELPER_MODE) else {
+		return Ok(());
+	};
+	let (stdin_handle, stdout_handle, stderr_handle) = terminal_handles()?;
+
+	match mode.as_str() {
+		"terminal" => {
+			print!(
+				"PW-TERMINALS:{}{}{}:{}:REMOVED={}:CWD={}",
+				is_console(stdin_handle) as u8,
+				is_console(stdout_handle) as u8,
+				is_console(stderr_handle) as u8,
+				env::var("PW_VALUE").unwrap_or_default(),
+				env::var_os("PW_REMOVED").is_none() as u8,
+				env::current_dir()?.display(),
+			);
+			eprint!("PW-STDERR");
+			io::stdout().flush()?;
+			io::stderr().flush()?;
+		}
+		"io" => {
+			let mut console_mode = Default::default();
+			// SAFETY: stdin_handle is the live console input handle and console_mode is writable.
+			unsafe { GetConsoleMode(stdin_handle, &mut console_mode) }.map_err(io::Error::other)?;
+			console_mode &= !(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
+			// SAFETY: stdin_handle remains live and console_mode is a valid combination of input flags.
+			unsafe { SetConsoleMode(stdin_handle, console_mode) }.map_err(io::Error::other)?;
+			print!("PW-READY");
+			io::stdout().flush()?;
+			let mut bytes = [0; 4];
+			io::stdin().read_exact(&mut bytes)?;
+			io::stdout().write_all(b"PW-BYTES:")?;
+			io::stdout().write_all(&bytes)?;
+			io::stdout().flush()?;
+		}
+		"size" => {
+			print_size(stdout_handle)?;
+			io::stdout().flush()?;
+			let mut line = String::new();
+			io::stdin().read_line(&mut line)?;
+			print_size(stdout_handle)?;
+			io::stdout().flush()?;
+		}
+		"wait" => {
+			print!("PW-READY");
+			io::stdout().flush()?;
+			let mut byte = [0];
+			loop {
+				io::stdin().read_exact(&mut byte)?;
+			}
+		}
+		other => panic!("unknown ConPTY helper mode {other}"),
+	}
+	Ok(())
+}
+
+fn print_size(output: HANDLE) -> io::Result<()> {
+	let mut info = Default::default();
+	// SAFETY: output is a live console output handle and info is writable output storage.
+	unsafe { GetConsoleScreenBufferInfo(output, &mut info) }.map_err(io::Error::other)?;
+	print!("PW-SIZE:{}x{}", info.dwSize.Y, info.dwSize.X);
+	Ok(())
+}
+
+#[tokio::test]
+async fn exposes_terminal_handles_and_preserves_environment_cwd_and_merged_output() -> io::Result<()>
+{
+	let directory = tempfile::tempdir()?;
+	let system_root = env::var_os("SystemRoot").expect("Windows must define SystemRoot");
+	let mut command = helper("terminal")?;
+	command
+		.env("PW_DISCARDED", "before-clear")
+		.env_clear()
+		.env("SystemRoot", system_root)
+		.env(HELPER_MODE, "terminal")
+		.env("PW_VALUE", "child-value")
+		.env("PW_REMOVED", "discarded")
+		.env_remove("PW_REMOVED")
+		.current_dir(directory.path());
+
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	assert!(timeout(TIMEOUT, child.wait()).await??.success());
+	let mut bytes = Vec::new();
+	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	let marker = format!(
+		"PW-TERMINALS:111:child-value:REMOVED=1:CWD={}",
+		directory.path().display()
+	);
+	assert!(
+		bytes
+			.windows(marker.len())
+			.any(|window| window == marker.as_bytes()),
+		"{}",
+		String::from_utf8_lossy(&bytes)
+	);
+	assert!(
+		bytes
+			.windows(b"PW-STDERR".len())
+			.any(|window| window == b"PW-STDERR"),
+		"{}",
+		String::from_utf8_lossy(&bytes)
+	);
+	Ok(())
+}
+
+#[tokio::test]
+async fn passes_bidirectional_terminal_bytes() -> io::Result<()> {
+	let mut command = helper("io")?;
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (mut input, mut output, _resize) = controller.into_parts();
+	let mut bytes = read_through(&mut output, b"PW-READY").await?;
+
+	let controls = [b'A', 0x1b, b'B', b'C'];
+	input.write_all(&controls).await?;
+	input.shutdown().await?;
+	assert!(timeout(TIMEOUT, child.wait()).await??.success());
+	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	let mut expected = b"PW-BYTES:".to_vec();
+	expected.extend(controls);
+	assert!(
+		bytes
+			.windows(expected.len())
+			.any(|window| window == expected.as_slice()),
+		"{:?}",
+		bytes
+	);
+	Ok(())
+}
+
+#[tokio::test]
+async fn reports_initial_size_and_resize() -> io::Result<()> {
+	let mut command = helper("size")?;
+	let initial = PtySize::new(31, 97)?;
+	let (mut child, controller) = command.spawn(PtyOptions::new(initial))?;
+	let (mut input, mut output, resize) = controller.into_parts();
+	read_through(&mut output, b"PW-SIZE:31x97").await?;
+	resize.resize(PtySize::new(42, 113)?)?;
+	input.write_all(b"go\r").await?;
+	read_through(&mut output, b"PW-SIZE:42x113").await?;
+	assert!(timeout(TIMEOUT, child.wait()).await??.success());
+	Ok(())
+}
+
+#[tokio::test]
+async fn canceled_wait_kill_and_repeated_waits_remain_valid() -> io::Result<()> {
+	let mut command = helper("wait")?;
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	read_through(&mut output, b"PW-READY").await?;
+	assert!(
+		timeout(Duration::from_millis(20), child.wait())
+			.await
+			.is_err()
+	);
+	child.start_kill()?;
+	let status = timeout(TIMEOUT, child.wait()).await??;
+	assert_eq!(child.try_wait()?, Some(status));
+	assert_eq!(child.wait().await?, status);
+	drop(input);
+	let mut trailing = Vec::new();
+	timeout(TIMEOUT, output.read_to_end(&mut trailing)).await??;
+	Ok(())
+}
+
+#[tokio::test]
+async fn shutting_down_input_releases_its_owner_without_early_hangup() -> io::Result<()> {
+	let mut command = helper("wait")?;
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (mut input, mut output, resize) = controller.into_parts();
+	read_through(&mut output, b"PW-READY").await?;
+
+	input.shutdown().await?;
+	assert_eq!(
+		input.write_all(b"closed").await.unwrap_err().kind(),
+		io::ErrorKind::BrokenPipe
+	);
+	assert!(child.try_wait()?.is_none());
+	resize.resize(PtySize::default())?;
+	drop(output);
+	assert_eq!(
+		resize.resize(PtySize::default()).unwrap_err().kind(),
+		io::ErrorKind::BrokenPipe
+	);
+	timeout(TIMEOUT, child.wait()).await??;
+	Ok(())
+}
+
+#[tokio::test]
+async fn dropping_output_keeps_the_terminal_live_while_input_exists() -> io::Result<()> {
+	let mut command = helper("wait")?;
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, resize) = controller.into_parts();
+	read_through(&mut output, b"PW-READY").await?;
+	drop(output);
+	assert!(child.try_wait()?.is_none());
+	resize.resize(PtySize::default())?;
+	drop(input);
+	assert_eq!(
+		resize.resize(PtySize::default()).unwrap_err().kind(),
+		io::ErrorKind::BrokenPipe
+	);
+	timeout(TIMEOUT, child.wait()).await??;
+	Ok(())
+}
+
+#[tokio::test]
+async fn failed_spawn_leaves_the_tracked_command_reusable() -> io::Result<()> {
+	let mut command = PtyCommand::new("process-wrap-definitely-missing-program");
+	assert_eq!(
+		command.spawn(PtyOptions::default()).unwrap_err().kind(),
+		io::ErrorKind::NotFound
+	);
+	command
+		.program(env::current_exe()?)
+		.args(["--exact", "conpty_child_helper", "--nocapture"])
+		.env(HELPER_MODE, "terminal");
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	assert!(timeout(TIMEOUT, child.wait()).await??.success());
+	let mut bytes = Vec::new();
+	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		bytes
+			.windows(16)
+			.any(|window| window == b"PW-TERMINALS:111")
+	);
+	Ok(())
+}
+
+#[tokio::test]
+async fn accepts_ordered_raw_argument_fragments() -> io::Result<()> {
+	let mut command = PtyCommand::new(env::current_exe()?);
+	command
+		.arg("--exact")
+		.raw_arg("conpty_child_helper")
+		.arg("--nocapture")
+		.env(HELPER_MODE, "terminal");
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	assert!(timeout(TIMEOUT, child.wait()).await??.success());
+	let mut bytes = Vec::new();
+	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	assert!(
+		bytes
+			.windows(16)
+			.any(|window| window == b"PW-TERMINALS:111")
+	);
+	Ok(())
+}
+
+#[derive(Debug)]
+struct UnsupportedWrapper;
+
+impl CommandWrapper for UnsupportedWrapper {
+	fn pre_spawn(
+		&mut self,
+		_command: &mut tokio::process::Command,
+		_core: &CommandWrap,
+	) -> io::Result<()> {
+		panic!("unsupported Windows PTY wrappers must be rejected before hooks")
+	}
+}
+
+#[test]
+fn rejects_unknown_wrappers_before_spawn_hooks() -> io::Result<()> {
+	let mut command = helper("terminal")?;
+	command.wrap(UnsupportedWrapper);
+	let error = command.spawn(PtyOptions::default()).unwrap_err();
+	assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+	assert!(error.to_string().contains("UnsupportedWrapper"));
+	Ok(())
+}

--- a/tests/tokio_pty_windows.rs
+++ b/tests/tokio_pty_windows.rs
@@ -3,6 +3,7 @@
 use std::{
 	env,
 	io::{self, Read, Write},
+	path::{Path, PathBuf},
 	time::Duration,
 };
 
@@ -26,6 +27,10 @@ use windows::Win32::{
 	},
 };
 
+#[cfg(all(feature = "creation-flags", feature = "job-object"))]
+#[path = "support/windows_thread.rs"]
+mod windows_thread;
+
 const HELPER_MODE: &str = "PROCESS_WRAP_CONPTY_HELPER";
 const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -35,6 +40,23 @@ fn helper(mode: &str) -> io::Result<PtyCommand> {
 		.args(["--exact", "conpty_child_helper", "--nocapture"])
 		.env(HELPER_MODE, mode);
 	Ok(command)
+}
+
+fn spawn_descendant(release: &Path) -> io::Result<std::process::Child> {
+	std::process::Command::new(env::current_exe()?)
+		.args(["--exact", "conpty_child_helper", "--nocapture"])
+		.env(HELPER_MODE, "descendant")
+		.env("PW_RELEASE", release)
+		.env_remove("PW_DESCENDANT_PID")
+		.spawn()
+}
+
+struct ReleaseOnDrop(PathBuf);
+
+impl Drop for ReleaseOnDrop {
+	fn drop(&mut self) {
+		let _ = std::fs::File::create(&self.0);
+	}
 }
 
 async fn read_through(
@@ -86,9 +108,6 @@ fn conpty_child_helper() -> io::Result<()> {
 
 	match mode.as_str() {
 		"terminal" => {
-			if let Some(path) = env::var_os("PW_TOUCH") {
-				std::fs::File::create(path)?;
-			}
 			print!(
 				"PW-TERMINALS:{}{}{}:{}:REMOVED={}:CWD={}",
 				is_console(stdin_handle) as u8,
@@ -124,6 +143,39 @@ fn conpty_child_helper() -> io::Result<()> {
 			io::stdin().read_line(&mut line)?;
 			print_size(stdout_handle)?;
 			io::stdout().flush()?;
+		}
+		"descendant-parent" => {
+			let release = env::var_os("PW_RELEASE").ok_or_else(|| {
+				io::Error::new(io::ErrorKind::InvalidInput, "PW_RELEASE is unset")
+			})?;
+			drop(spawn_descendant(Path::new(&release))?);
+		}
+		"descendant" => {
+			let release = env::var_os("PW_RELEASE").ok_or_else(|| {
+				io::Error::new(io::ErrorKind::InvalidInput, "PW_RELEASE is unset")
+			})?;
+			print!("PW-DESCENDANT-READY");
+			io::stdout().flush()?;
+			while !Path::new(&release).exists() {
+				std::thread::sleep(Duration::from_millis(10));
+			}
+		}
+		"tree" => {
+			let release = env::var_os("PW_RELEASE").ok_or_else(|| {
+				io::Error::new(io::ErrorKind::InvalidInput, "PW_RELEASE is unset")
+			})?;
+			let pid_file = env::var_os("PW_DESCENDANT_PID").ok_or_else(|| {
+				io::Error::new(io::ErrorKind::InvalidInput, "PW_DESCENDANT_PID is unset")
+			})?;
+			let descendant = spawn_descendant(Path::new(&release))?;
+			std::fs::write(pid_file, descendant.id().to_string())?;
+			drop(descendant);
+			print!("PW-TREE-READY");
+			io::stdout().flush()?;
+			let mut byte = [0];
+			loop {
+				io::stdin().read_exact(&mut byte)?;
+			}
 		}
 		"wait" => {
 			print!("PW-READY");
@@ -290,6 +342,30 @@ async fn dropping_output_keeps_the_terminal_live_while_input_exists() -> io::Res
 }
 
 #[tokio::test]
+async fn direct_child_wait_is_independent_from_descendant_output_eof() -> io::Result<()> {
+	let directory = tempfile::tempdir()?;
+	let release = directory.path().join("release-descendant");
+	let _release_on_drop = ReleaseOnDrop(release.clone());
+	let mut command = helper("descendant-parent")?;
+	command.env("PW_RELEASE", &release);
+
+	let (mut child, controller) = command.spawn(PtyOptions::default())?;
+	let (input, mut output, _resize) = controller.into_parts();
+	drop(input);
+	let mut bytes = read_through(&mut output, b"PW-DESCENDANT-READY").await?;
+	assert!(timeout(TIMEOUT, child.wait()).await??.success());
+	assert!(
+		timeout(Duration::from_millis(100), output.read_to_end(&mut bytes))
+			.await
+			.is_err(),
+		"ConPTY output reached EOF while a descendant remained attached"
+	);
+	std::fs::File::create(&release)?;
+	timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
+	Ok(())
+}
+
+#[tokio::test]
 async fn failed_spawn_leaves_the_tracked_command_reusable() -> io::Result<()> {
 	let mut command = PtyCommand::new("process-wrap-definitely-missing-program");
 	assert_eq!(
@@ -412,19 +488,16 @@ async fn job_object_composes_with_creation_flags_in_both_orders() -> io::Result<
 async fn job_object_preserves_explicit_suspension() -> io::Result<()> {
 	use windows::Win32::System::Threading::CREATE_SUSPENDED;
 
-	let directory = tempfile::tempdir()?;
-	let touched = directory.path().join("resumed");
 	let mut command = helper("terminal")?;
 	command
-		.env("PW_TOUCH", &touched)
 		.wrap(CreationFlags(CREATE_SUSPENDED))
 		.wrap(JobObject);
 	let (mut child, controller) = command.spawn(PtyOptions::default())?;
 	let (input, mut output, _resize) = controller.into_parts();
-	tokio::time::sleep(Duration::from_millis(500)).await;
+	let pid = child.id().expect("ConPTY children expose a process ID");
 	assert!(
-		!touched.exists(),
-		"an explicitly suspended ConPTY child started running"
+		windows_thread::process_has_suspended_thread(pid)?,
+		"an explicitly suspended ConPTY child had no suspended thread"
 	);
 	child.start_kill()?;
 	timeout(TIMEOUT, child.wait()).await??;
@@ -437,6 +510,70 @@ async fn job_object_preserves_explicit_suspension() -> io::Result<()> {
 			.any(|window| window == b"PW-TERMINALS:111")
 	);
 	Ok(())
+}
+
+#[cfg(all(feature = "job-object", feature = "kill-on-drop"))]
+struct ProcessGuard(Option<std::os::windows::io::OwnedHandle>);
+
+#[cfg(all(feature = "job-object", feature = "kill-on-drop"))]
+impl ProcessGuard {
+	fn open(pid: u32) -> io::Result<Self> {
+		use std::os::windows::io::FromRawHandle;
+		use windows::Win32::System::Threading::{
+			OpenProcess, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
+		};
+
+		// SAFETY: pid identifies the live descendant and the returned handle is non-inheritable.
+		let process = unsafe { OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_TERMINATE, false, pid) }
+			.map_err(io::Error::other)?;
+		// SAFETY: OpenProcess returned a unique owned handle.
+		Ok(Self(Some(unsafe {
+			std::os::windows::io::OwnedHandle::from_raw_handle(process.0)
+		})))
+	}
+
+	fn wait(self) -> io::Result<Self> {
+		use std::os::windows::io::AsRawHandle;
+		use windows::Win32::{
+			Foundation::{WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT},
+			System::Threading::WaitForSingleObject,
+		};
+
+		let process = self.0.as_ref().expect("a process guard must be armed");
+		// SAFETY: the guard owns the live process synchronization handle.
+		match unsafe { WaitForSingleObject(HANDLE(process.as_raw_handle()), 10_000) } {
+			WAIT_OBJECT_0 => Ok(self),
+			WAIT_TIMEOUT => Err(io::Error::new(
+				io::ErrorKind::TimedOut,
+				"ConPTY descendant survived dropping the job",
+			)),
+			WAIT_FAILED => Err(io::Error::last_os_error()),
+			result => Err(io::Error::other(format!(
+				"unexpected descendant wait result {}",
+				result.0
+			))),
+		}
+	}
+
+	fn disarm(mut self) {
+		self.0.take();
+	}
+}
+
+#[cfg(all(feature = "job-object", feature = "kill-on-drop"))]
+impl Drop for ProcessGuard {
+	fn drop(&mut self) {
+		use std::os::windows::io::AsRawHandle;
+		use windows::Win32::System::Threading::{INFINITE, TerminateProcess, WaitForSingleObject};
+
+		if let Some(process) = self.0.take() {
+			let process = HANDLE(process.as_raw_handle());
+			// SAFETY: the guard owns this process handle and is cleaning up a failed test descendant.
+			let _ = unsafe { TerminateProcess(process, 1) };
+			// SAFETY: the owned handle remains live until the end of this scope.
+			let _ = unsafe { WaitForSingleObject(process, INFINITE) };
+		}
+	}
 }
 
 #[cfg(feature = "kill-on-drop")]
@@ -477,13 +614,35 @@ async fn kill_on_drop_terminates_a_conpty_child() -> io::Result<()> {
 #[tokio::test]
 async fn job_object_composes_with_kill_on_drop_in_both_orders() -> io::Result<()> {
 	for reverse in [false, true] {
-		let mut command = helper("wait")?;
+		let directory = tempfile::tempdir()?;
+		let release = directory.path().join("release-descendant");
+		let pid_file = directory.path().join("descendant-pid");
+		let _release_on_drop = ReleaseOnDrop(release.clone());
+		let mut command = helper("tree")?;
+		command
+			.env("PW_RELEASE", &release)
+			.env("PW_DESCENDANT_PID", &pid_file);
 		if reverse {
 			command.wrap(JobObject).wrap(KillOnDrop);
 		} else {
 			command.wrap(KillOnDrop).wrap(JobObject);
 		}
-		assert_killed_on_drop(command).await?;
+
+		let (child, controller) = command.spawn(PtyOptions::default())?;
+		let (input, mut output, _resize) = controller.into_parts();
+		read_through(&mut output, b"PW-TREE-READY").await?;
+		let pid = std::fs::read_to_string(&pid_file)?
+			.parse::<u32>()
+			.map_err(io::Error::other)?;
+		let guard = ProcessGuard::open(pid)?;
+		drop(child);
+		let guard = tokio::task::spawn_blocking(move || guard.wait())
+			.await
+			.map_err(io::Error::other)??;
+		guard.disarm();
+		drop(input);
+		let mut bytes = Vec::new();
+		timeout(TIMEOUT, output.read_to_end(&mut bytes)).await??;
 	}
 	Ok(())
 }

--- a/tests/tokio_pty_windows.rs
+++ b/tests/tokio_pty_windows.rs
@@ -24,9 +24,9 @@ use tokio::{
 use windows::Win32::{
 	Foundation::HANDLE,
 	System::Console::{
-		ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT, GetConsoleMode,
-		GetConsoleScreenBufferInfo, GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE,
-		STD_OUTPUT_HANDLE, SetConsoleMode,
+		ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT,
+		ENABLE_VIRTUAL_TERMINAL_INPUT, GetConsoleMode, GetConsoleScreenBufferInfo, GetStdHandle,
+		STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, SetConsoleMode,
 	},
 };
 
@@ -139,6 +139,7 @@ fn conpty_child_helper() -> io::Result<()> {
 			// SAFETY: stdin_handle is the live console input handle and console_mode is writable.
 			unsafe { GetConsoleMode(stdin_handle, &mut console_mode) }.map_err(io::Error::other)?;
 			console_mode &= !(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
+			console_mode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
 			// SAFETY: stdin_handle remains live and console_mode is a valid combination of input flags.
 			unsafe { SetConsoleMode(stdin_handle, console_mode) }.map_err(io::Error::other)?;
 			print!("PW-READY");


### PR DESCRIPTION
- dynamically resolve the complete ConPTY capability set so the crate still loads on older Windows versions
- add a custom `ConPtyChild` with cancellation-safe, repeatable wait/try-wait/kill behavior
- preserve cleanup across process creation, wrapper errors, panics, JobObject assignment, and controller construction
- compose `CreationFlags`, `JobObject`, and `KillOnDrop` in supported orders

Because natural EOF requires `ReleasePseudoConsole`, runtime support starts at Windows 11 24H2 (build 26100) and Windows Server 2025. Older Windows releases receive `io::ErrorKind::Unsupported` from PTY spawning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
