### PR TITLE
fix(windows): confirm job and descendant completion before returning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tokio1 = ["dep:nix", "dep:futures", "dep:tokio"]
 creation-flags = ["dep:windows", "windows/Win32_System_Threading"]
 
 ## Wrapper: Job Object
-job-object = ["dep:windows", "windows/Win32_Security", "windows/Win32_System_Diagnostics_ToolHelp", "windows/Win32_System_IO", "windows/Win32_System_JobObjects", "windows/Win32_System_Threading"]
+job-object = ["dep:windows", "windows/Win32_Security", "windows/Win32_System_Diagnostics_ToolHelp", "windows/Win32_System_IO", "windows/Win32_System_JobObjects", "windows/Win32_System_SystemServices", "windows/Win32_System_Threading"]
 
 ## Wrapper: Kill on Drop
 kill-on-drop = []

--- a/src/std/job_object.rs
+++ b/src/std/job_object.rs
@@ -176,19 +176,35 @@ impl ChildWrapper for JobObjectChild {
 		// always wait for parent to exit first, as by the time it does,
 		// it's likely that all its children have already exited.
 		let status = self.inner.wait()?;
-		self.exit_status = ChildExitStatus::Exited(status);
 
 		// nevertheless, now wait and make sure we reap all children.
 		let JobPort {
-			completion_port, ..
+			job,
+			completion_port,
 		} = self.job_port;
-		let _ = wait_on_job(completion_port, None)?;
+		let _ = wait_on_job(job, completion_port, None)?;
+		self.exit_status = ChildExitStatus::Exited(status);
 		Ok(status)
 	}
 
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
-		let _ = wait_on_job(self.job_port.completion_port, Some(Duration::ZERO))?;
-		self.inner.try_wait()
+		if let ChildExitStatus::Exited(status) = self.exit_status {
+			return Ok(Some(status));
+		}
+		if wait_on_job(
+			self.job_port.job,
+			self.job_port.completion_port,
+			Some(Duration::ZERO),
+		)?
+		.is_continue()
+		{
+			return Ok(None);
+		}
+		let status = self.inner.try_wait()?;
+		if let Some(status) = status {
+			self.exit_status = ChildExitStatus::Exited(status);
+		}
+		Ok(status)
 	}
 }

--- a/src/std/job_object.rs
+++ b/src/std/job_object.rs
@@ -10,10 +10,7 @@ use std::{
 
 #[cfg(feature = "tracing")]
 use tracing::{debug, instrument};
-use windows::Win32::{
-	Foundation::{CloseHandle, HANDLE},
-	System::Threading::PROCESS_CREATION_FLAGS,
-};
+use windows::Win32::{Foundation::HANDLE, System::Threading::PROCESS_CREATION_FLAGS};
 
 use crate::{
 	ChildExitStatus,
@@ -150,11 +147,7 @@ impl ChildWrapper for JobObjectChild {
 		self.inner.as_mut()
 	}
 	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
-		// manually drop the completion port
-		let its = std::mem::ManuallyDrop::new(self.job_port);
-		unsafe { CloseHandle(its.completion_port.0) }.ok();
-		// we leave the job handle unclosed, otherwise the Child is useless
-		// (as closing it will terminate the job)
+		self.job_port.detach();
 
 		self.inner
 	}
@@ -178,11 +171,7 @@ impl ChildWrapper for JobObjectChild {
 		let status = self.inner.wait()?;
 
 		// nevertheless, now wait and make sure we reap all children.
-		let JobPort {
-			job,
-			completion_port,
-		} = self.job_port;
-		let _ = wait_on_job(job, completion_port, None)?;
+		let _ = wait_on_job(&self.job_port, None)?;
 		self.exit_status = ChildExitStatus::Exited(status);
 		Ok(status)
 	}
@@ -192,13 +181,7 @@ impl ChildWrapper for JobObjectChild {
 		if let ChildExitStatus::Exited(status) = self.exit_status {
 			return Ok(Some(status));
 		}
-		if wait_on_job(
-			self.job_port.job,
-			self.job_port.completion_port,
-			Some(Duration::ZERO),
-		)?
-		.is_continue()
-		{
+		if wait_on_job(&self.job_port, Some(Duration::ZERO))?.is_continue() {
 			return Ok(None);
 		}
 		let status = self.inner.try_wait()?;

--- a/src/tokio/job_object.rs
+++ b/src/tokio/job_object.rs
@@ -180,33 +180,57 @@ impl ChildWrapper for JobObjectChild {
 				return Ok(*status);
 			}
 
-			const MAX_RETRY_ATTEMPT: usize = 10;
-
-			// always wait for parent to exit first, as by the time it does,
-			// it's likely that all its children have already exited.
 			let status = self.inner.wait().await?;
-			self.exit_status = ChildExitStatus::Exited(status);
-
-			// nevertheless, now try reaping all children a few times...
-			for _ in 1..MAX_RETRY_ATTEMPT {
-				if wait_on_job(self.job_port.completion_port, Some(Duration::ZERO))?.is_break() {
-					return Ok(status);
+			loop {
+				if wait_on_job(
+					self.job_port.job,
+					self.job_port.completion_port,
+					Some(Duration::ZERO),
+				)?
+				.is_break()
+				{
+					break;
+				}
+				// A cancelled future must not leave an unbounded waiter borrowing closed handles.
+				let owned = self.job_port.try_clone()?;
+				if spawn_blocking(move || {
+					let result = wait_on_job(
+						owned.job,
+						owned.completion_port,
+						Some(Duration::from_millis(10)),
+					);
+					drop(owned);
+					result
+				})
+				.await??
+				.is_break()
+				{
+					break;
 				}
 			}
-
-			// ...finally, if there are some that are still alive,
-			// block in the background to reap them fully.
-			let JobPort {
-				completion_port, ..
-			} = self.job_port;
-			let _ = spawn_blocking(move || wait_on_job(completion_port, None)).await??;
+			self.exit_status = ChildExitStatus::Exited(status);
 			Ok(status)
 		})
 	}
 
 	#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(self)))]
 	fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
-		let _ = wait_on_job(self.job_port.completion_port, Some(Duration::ZERO))?;
-		self.inner.try_wait()
+		if let ChildExitStatus::Exited(status) = self.exit_status {
+			return Ok(Some(status));
+		}
+		if wait_on_job(
+			self.job_port.job,
+			self.job_port.completion_port,
+			Some(Duration::ZERO),
+		)?
+		.is_continue()
+		{
+			return Ok(None);
+		}
+		let status = self.inner.try_wait()?;
+		if let Some(status) = status {
+			self.exit_status = ChildExitStatus::Exited(status);
+		}
+		Ok(status)
 	}
 }

--- a/src/tokio/job_object.rs
+++ b/src/tokio/job_object.rs
@@ -10,10 +10,7 @@ use std::{
 use tokio::{process::Command, task::spawn_blocking};
 #[cfg(feature = "tracing")]
 use tracing::{debug, instrument};
-use windows::Win32::{
-	Foundation::{CloseHandle, HANDLE},
-	System::Threading::PROCESS_CREATION_FLAGS,
-};
+use windows::Win32::{Foundation::HANDLE, System::Threading::PROCESS_CREATION_FLAGS};
 
 use crate::{
 	ChildExitStatus,
@@ -156,11 +153,7 @@ impl ChildWrapper for JobObjectChild {
 		self.inner.as_mut()
 	}
 	fn into_inner(self: Box<Self>) -> Box<dyn ChildWrapper> {
-		// manually drop the completion port
-		let its = std::mem::ManuallyDrop::new(self.job_port);
-		unsafe { CloseHandle(its.completion_port.0) }.ok();
-		// we leave the job handle unclosed, otherwise the Child is useless
-		// (as closing it will terminate the job)
+		self.job_port.detach();
 
 		self.inner
 	}
@@ -182,23 +175,13 @@ impl ChildWrapper for JobObjectChild {
 
 			let status = self.inner.wait().await?;
 			loop {
-				if wait_on_job(
-					self.job_port.job,
-					self.job_port.completion_port,
-					Some(Duration::ZERO),
-				)?
-				.is_break()
-				{
+				if wait_on_job(&self.job_port, Some(Duration::ZERO))?.is_break() {
 					break;
 				}
 				// A cancelled future must not leave an unbounded waiter borrowing closed handles.
 				let owned = self.job_port.try_clone()?;
 				if spawn_blocking(move || {
-					let result = wait_on_job(
-						owned.job,
-						owned.completion_port,
-						Some(Duration::from_millis(10)),
-					);
+					let result = wait_on_job(&owned, Some(Duration::from_millis(10)));
 					drop(owned);
 					result
 				})
@@ -218,13 +201,7 @@ impl ChildWrapper for JobObjectChild {
 		if let ChildExitStatus::Exited(status) = self.exit_status {
 			return Ok(Some(status));
 		}
-		if wait_on_job(
-			self.job_port.job,
-			self.job_port.completion_port,
-			Some(Duration::ZERO),
-		)?
-		.is_continue()
-		{
+		if wait_on_job(&self.job_port, Some(Duration::ZERO))?.is_continue() {
 			return Ok(None);
 		}
 		let status = self.inner.try_wait()?;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -24,12 +24,13 @@ use windows::{
 			IO::{CreateIoCompletionPort, GetQueuedCompletionStatus, OVERLAPPED},
 			JobObjects::{
 				AssignProcessToJobObject, CreateJobObjectW, IsProcessInJob,
-				JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, JOB_OBJECT_MSG_NEW_PROCESS,
+				JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
 				JOBOBJECT_ASSOCIATE_COMPLETION_PORT, JOBOBJECT_BASIC_ACCOUNTING_INFORMATION,
 				JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectAssociateCompletionPortInformation,
 				JobObjectBasicAccountingInformation, JobObjectExtendedLimitInformation,
 				QueryInformationJobObject, SetInformationJobObject, TerminateJobObject,
 			},
+			SystemServices::JOB_OBJECT_MSG_NEW_PROCESS,
 			Threading::{
 				CREATE_SUSPENDED, GetProcessId, OpenProcess, OpenThread, PROCESS_CREATION_FLAGS,
 				PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, ResumeThread,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -24,11 +24,11 @@ use windows::{
 			IO::{CreateIoCompletionPort, GetQueuedCompletionStatus, OVERLAPPED},
 			JobObjects::{
 				AssignProcessToJobObject, CreateJobObjectW, IsProcessInJob,
-				JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-				JOBOBJECT_ASSOCIATE_COMPLETION_PORT, JOBOBJECT_BASIC_ACCOUNTING_INFORMATION,
-				JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectAssociateCompletionPortInformation,
-				JobObjectBasicAccountingInformation, JobObjectExtendedLimitInformation,
-				QueryInformationJobObject, SetInformationJobObject, TerminateJobObject,
+				JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, JOBOBJECT_ASSOCIATE_COMPLETION_PORT,
+				JOBOBJECT_BASIC_ACCOUNTING_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+				JobObjectAssociateCompletionPortInformation, JobObjectBasicAccountingInformation,
+				JobObjectExtendedLimitInformation, QueryInformationJobObject,
+				SetInformationJobObject, TerminateJobObject,
 			},
 			SystemServices::JOB_OBJECT_MSG_NEW_PROCESS,
 			Threading::{

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -3,6 +3,8 @@
 use std::{
 	io::{Error, Result},
 	ops::ControlFlow,
+	os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle as ProcessHandle},
+	sync::{Arc, Mutex, TryLockError},
 	time::{Duration, Instant},
 };
 
@@ -11,7 +13,8 @@ use tracing::{debug, instrument};
 use windows::{
 	Win32::{
 		Foundation::{
-			CloseHandle, ERROR_NO_MORE_FILES, HANDLE, INVALID_HANDLE_VALUE, WAIT_TIMEOUT,
+			CloseHandle, ERROR_INVALID_PARAMETER, ERROR_NO_MORE_FILES, HANDLE,
+			INVALID_HANDLE_VALUE, WAIT_OBJECT_0, WAIT_TIMEOUT,
 		},
 		System::{
 			Diagnostics::ToolHelp::{
@@ -20,15 +23,17 @@ use windows::{
 			},
 			IO::{CreateIoCompletionPort, GetQueuedCompletionStatus, OVERLAPPED},
 			JobObjects::{
-				AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+				AssignProcessToJobObject, CreateJobObjectW, IsProcessInJob,
+				JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, JOB_OBJECT_MSG_NEW_PROCESS,
 				JOBOBJECT_ASSOCIATE_COMPLETION_PORT, JOBOBJECT_BASIC_ACCOUNTING_INFORMATION,
 				JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectAssociateCompletionPortInformation,
 				JobObjectBasicAccountingInformation, JobObjectExtendedLimitInformation,
 				QueryInformationJobObject, SetInformationJobObject, TerminateJobObject,
 			},
 			Threading::{
-				CREATE_SUSPENDED, GetProcessId, OpenThread, PROCESS_CREATION_FLAGS, ResumeThread,
-				THREAD_SUSPEND_RESUME,
+				CREATE_SUSPENDED, GetProcessId, OpenProcess, OpenThread, PROCESS_CREATION_FLAGS,
+				PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, ResumeThread,
+				THREAD_SUSPEND_RESUME, WaitForSingleObject,
 			},
 		},
 	},
@@ -107,6 +112,14 @@ unsafe impl Sync for PortHandle {}
 pub(crate) struct JobPort {
 	pub job: JobHandle,
 	pub completion_port: PortHandle,
+	completion: Arc<Mutex<JobCompletion>>,
+}
+
+impl JobPort {
+	pub(crate) fn detach(mut self) {
+		// into_inner preserves the original job lifetime while releasing observation resources.
+		self.job = JobHandle(INVALID_HANDLE_VALUE);
+	}
 }
 
 #[cfg(feature = "tokio1")]
@@ -119,6 +132,7 @@ impl JobPort {
 		Ok(Self {
 			job: JobHandle(HANDLE(job.into_raw_handle())),
 			completion_port: PortHandle(HANDLE(port.into_raw_handle())),
+			completion: Arc::clone(&self.completion),
 		})
 	}
 }
@@ -189,7 +203,13 @@ pub(crate) fn make_job_object(process_handle: HANDLE, kill_on_drop: bool) -> Res
 	#[cfg(feature = "tracing")]
 	debug!(?job, ?process_handle, "done AssignProcessToJobObject");
 
+	let completion = Arc::new(Mutex::new(JobCompletion {
+		key: job.0.0 as usize,
+		observed: 0,
+		pending: Vec::new(),
+	}));
 	Ok(JobPort {
+		completion,
 		job: JobHandle(job.into_raw()),
 		completion_port: PortHandle(completion_port.into_raw()),
 	})
@@ -257,15 +277,82 @@ pub(crate) fn terminate_job(job: JobHandle, exit_code: u32) -> Result<()> {
 	unsafe { TerminateJobObject(job.0, exit_code) }.map_err(Error::other)
 }
 
-/// Wait for a job to complete.
-#[cfg_attr(feature = "tracing", instrument(level = "debug"))]
-pub(crate) fn wait_on_job(
-	job: JobHandle,
-	completion_port: PortHandle,
-	timeout: Option<Duration>,
-) -> Result<ControlFlow<()>> {
-	let started = Instant::now();
-	loop {
+#[derive(Debug, Default)]
+struct JobCompletion {
+	key: usize,
+	observed: u32,
+	pending: Vec<ProcessHandle>,
+}
+
+impl JobCompletion {
+	fn observe_process(&mut self, job: JobHandle, pid: usize) -> Result<()> {
+		let observed = self
+			.observed
+			.checked_add(1)
+			.ok_or_else(|| Error::other("job process census overflow"))?;
+		let pid = u32::try_from(pid).map_err(Error::other)?;
+		let handle = match unsafe {
+			OpenProcess(
+				PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
+				false,
+				pid,
+			)
+		} {
+			Ok(handle) => unsafe { ProcessHandle::from_raw_handle(handle.0) },
+			Err(error) if error.code() == HRESULT::from_win32(ERROR_INVALID_PARAMETER.0) => {
+				self.observed = observed;
+				return Ok(());
+			}
+			Err(error) => return Err(Error::other(error)),
+		};
+		let mut belongs = Default::default();
+		unsafe { IsProcessInJob(HANDLE(handle.as_raw_handle()), Some(job.0), &mut belongs) }?;
+		if belongs.as_bool() {
+			self.pending.push(handle);
+		}
+		self.observed = observed;
+		Ok(())
+	}
+
+	fn poll(&mut self, job: JobHandle, port: PortHandle) -> Result<ControlFlow<()>> {
+		let mut drained = false;
+		for _ in 0..64 {
+			let mut code = 0;
+			let mut key = 0;
+			let mut overlapped: *mut OVERLAPPED = std::ptr::null_mut();
+			match unsafe {
+				GetQueuedCompletionStatus(port.0, &mut code, &mut key, &mut overlapped, 0)
+			} {
+				Ok(()) => {
+					if key != self.key {
+						return Err(Error::other("unexpected job completion key"));
+					}
+					if code == JOB_OBJECT_MSG_NEW_PROCESS {
+						self.observe_process(job, overlapped as usize)?;
+					}
+				}
+				Err(error) if error.code() == HRESULT::from_win32(WAIT_TIMEOUT.0) => {
+					drained = true;
+					break;
+				}
+				Err(error) => return Err(Error::other(error)),
+			}
+		}
+		if !drained {
+			return Ok(ControlFlow::Continue(()));
+		}
+		let mut index = 0;
+		while index < self.pending.len() {
+			match unsafe { WaitForSingleObject(HANDLE(self.pending[index].as_raw_handle()), 0) } {
+				WAIT_OBJECT_0 => {
+					self.pending.swap_remove(index);
+				}
+				WAIT_TIMEOUT => {
+					index += 1;
+				}
+				_ => return Err(Error::last_os_error()),
+			}
+		}
 		let mut accounting = JOBOBJECT_BASIC_ACCOUNTING_INFORMATION::default();
 		unsafe {
 			QueryInformationJobObject(
@@ -278,34 +365,54 @@ pub(crate) fn wait_on_job(
 				None,
 			)
 		}?;
-		if accounting.ActiveProcesses == 0 {
-			return Ok(ControlFlow::Break(()));
+		if accounting.ActiveProcesses != 0 {
+			return Ok(ControlFlow::Continue(()));
+		}
+		// Job accounting can reach zero before termination finishes, and notifications can be lost.
+		if self.observed != accounting.TotalProcesses {
+			return Err(Error::other(
+				"cannot confirm job completion: process notification census is incomplete",
+			));
+		}
+		Ok(if self.pending.is_empty() {
+			ControlFlow::Break(())
+		} else {
+			ControlFlow::Continue(())
+		})
+	}
+}
+
+/// Wait for a job and its observed processes to complete.
+#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(job_port)))]
+pub(crate) fn wait_on_job(
+	job_port: &JobPort,
+	timeout: Option<Duration>,
+) -> Result<ControlFlow<()>> {
+	let started = Instant::now();
+	loop {
+		match job_port.completion.try_lock() {
+			Ok(mut completion) => {
+				if completion
+					.poll(job_port.job, job_port.completion_port)?
+					.is_break()
+				{
+					return Ok(ControlFlow::Break(()));
+				}
+			}
+			Err(TryLockError::WouldBlock) => {}
+			Err(TryLockError::Poisoned(_)) => {
+				return Err(Error::other("job completion state is poisoned"));
+			}
 		}
 		let remaining = timeout.map(|timeout| timeout.saturating_sub(started.elapsed()));
 		if remaining == Some(Duration::ZERO) {
 			return Ok(ControlFlow::Continue(()));
 		}
-		// Job notifications can be unrelated or lost; accounting is the completion oracle.
-		let interval = remaining
-			.unwrap_or(Duration::from_millis(10))
-			.min(Duration::from_millis(10));
-		let mut code = 0;
-		let mut key = 0;
-		let mut overlapped: *mut OVERLAPPED = std::ptr::null_mut();
-		let result = unsafe {
-			GetQueuedCompletionStatus(
-				completion_port.0,
-				&mut code,
-				&mut key,
-				&mut overlapped,
-				interval.as_millis().max(1) as u32,
-			)
-		};
-		match result {
-			Ok(()) => {}
-			Err(error) if error.code() == HRESULT::from_win32(WAIT_TIMEOUT.0) => {}
-			Err(error) => return Err(Error::other(error)),
-		}
+		std::thread::sleep(
+			remaining
+				.unwrap_or(Duration::from_millis(10))
+				.min(Duration::from_millis(10)),
+		);
 	}
 }
 
@@ -314,9 +421,48 @@ mod wait_tests {
 	use super::*;
 
 	#[test]
+	fn incomplete_census_cannot_confirm_an_empty_job() -> Result<()> {
+		let job = OwnedHandle(unsafe { CreateJobObjectW(None, None) }?);
+		let port =
+			OwnedHandle(unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, None, 0, 1) }?);
+		let mut completion = JobCompletion {
+			observed: 1,
+			..Default::default()
+		};
+		for _ in 0..2 {
+			let error = completion
+				.poll(JobHandle(job.0), PortHandle(port.0))
+				.unwrap_err();
+			assert!(
+				error
+					.to_string()
+					.contains("process notification census is incomplete")
+			);
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn process_census_overflow_does_not_advance_observation() {
+		let mut completion = JobCompletion {
+			observed: u32::MAX,
+			..Default::default()
+		};
+		assert!(
+			completion
+				.observe_process(JobHandle(INVALID_HANDLE_VALUE), 0)
+				.is_err()
+		);
+		assert_eq!(completion.observed, u32::MAX);
+	}
+
+	#[test]
 	fn invalid_job_is_an_error_even_for_nonblocking_wait() {
-		let job = JobHandle(INVALID_HANDLE_VALUE);
-		let port = PortHandle(INVALID_HANDLE_VALUE);
-		assert!(wait_on_job(job, port, Some(Duration::ZERO)).is_err());
+		let job_port = JobPort {
+			job: JobHandle(INVALID_HANDLE_VALUE),
+			completion_port: PortHandle(INVALID_HANDLE_VALUE),
+			completion: Arc::default(),
+		};
+		assert!(wait_on_job(&job_port, Some(Duration::ZERO)).is_err());
 	}
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -3,14 +3,16 @@
 use std::{
 	io::{Error, Result},
 	ops::ControlFlow,
-	time::Duration,
+	time::{Duration, Instant},
 };
 
 #[cfg(feature = "tracing")]
 use tracing::{debug, instrument};
 use windows::{
 	Win32::{
-		Foundation::{CloseHandle, ERROR_NO_MORE_FILES, HANDLE, INVALID_HANDLE_VALUE},
+		Foundation::{
+			CloseHandle, ERROR_NO_MORE_FILES, HANDLE, INVALID_HANDLE_VALUE, WAIT_TIMEOUT,
+		},
 		System::{
 			Diagnostics::ToolHelp::{
 				CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First,
@@ -19,13 +21,14 @@ use windows::{
 			IO::{CreateIoCompletionPort, GetQueuedCompletionStatus, OVERLAPPED},
 			JobObjects::{
 				AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-				JOBOBJECT_ASSOCIATE_COMPLETION_PORT, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
-				JobObjectAssociateCompletionPortInformation, JobObjectExtendedLimitInformation,
-				SetInformationJobObject, TerminateJobObject,
+				JOBOBJECT_ASSOCIATE_COMPLETION_PORT, JOBOBJECT_BASIC_ACCOUNTING_INFORMATION,
+				JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectAssociateCompletionPortInformation,
+				JobObjectBasicAccountingInformation, JobObjectExtendedLimitInformation,
+				QueryInformationJobObject, SetInformationJobObject, TerminateJobObject,
 			},
 			Threading::{
-				CREATE_SUSPENDED, GetProcessId, INFINITE, OpenThread, PROCESS_CREATION_FLAGS,
-				ResumeThread, THREAD_SUSPEND_RESUME,
+				CREATE_SUSPENDED, GetProcessId, OpenThread, PROCESS_CREATION_FLAGS, ResumeThread,
+				THREAD_SUSPEND_RESUME,
 			},
 		},
 	},
@@ -104,6 +107,20 @@ unsafe impl Sync for PortHandle {}
 pub(crate) struct JobPort {
 	pub job: JobHandle,
 	pub completion_port: PortHandle,
+}
+
+#[cfg(feature = "tokio1")]
+impl JobPort {
+	pub(crate) fn try_clone(&self) -> Result<Self> {
+		use std::os::windows::io::{BorrowedHandle, IntoRawHandle};
+		let job = unsafe { BorrowedHandle::borrow_raw(self.job.0.0) }.try_clone_to_owned()?;
+		let port =
+			unsafe { BorrowedHandle::borrow_raw(self.completion_port.0.0) }.try_clone_to_owned()?;
+		Ok(Self {
+			job: JobHandle(HANDLE(job.into_raw_handle())),
+			completion_port: PortHandle(HANDLE(port.into_raw_handle())),
+		})
+	}
 }
 
 impl Drop for JobPort {
@@ -243,29 +260,63 @@ pub(crate) fn terminate_job(job: JobHandle, exit_code: u32) -> Result<()> {
 /// Wait for a job to complete.
 #[cfg_attr(feature = "tracing", instrument(level = "debug"))]
 pub(crate) fn wait_on_job(
+	job: JobHandle,
 	completion_port: PortHandle,
 	timeout: Option<Duration>,
 ) -> Result<ControlFlow<()>> {
-	let mut code: u32 = 0;
-	let mut key: usize = 0;
-	let mut overlapped = OVERLAPPED::default();
-	let mut lp_overlapped = &mut overlapped as *mut OVERLAPPED;
-
-	let result = unsafe {
-		GetQueuedCompletionStatus(
-			completion_port.0,
-			&mut code,
-			&mut key,
-			&mut lp_overlapped as *mut _,
-			timeout.map_or(INFINITE, |d| d.as_millis().try_into().unwrap_or(INFINITE)),
-		)
-	};
-
-	// ignore timing out errors unless the timeout was specified to INFINITE
-	// https://docs.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getqueuedcompletionstatus
-	if timeout.is_some() && result.is_err() && lp_overlapped.is_null() {
-		return Ok(ControlFlow::Continue(()));
+	let started = Instant::now();
+	loop {
+		let mut accounting = JOBOBJECT_BASIC_ACCOUNTING_INFORMATION::default();
+		unsafe {
+			QueryInformationJobObject(
+				Some(job.0),
+				JobObjectBasicAccountingInformation,
+				&mut accounting as *mut _ as _,
+				std::mem::size_of_val(&accounting)
+					.try_into()
+					.expect("accounting information fits in a DWORD"),
+				None,
+			)
+		}?;
+		if accounting.ActiveProcesses == 0 {
+			return Ok(ControlFlow::Break(()));
+		}
+		let remaining = timeout.map(|timeout| timeout.saturating_sub(started.elapsed()));
+		if remaining == Some(Duration::ZERO) {
+			return Ok(ControlFlow::Continue(()));
+		}
+		// Job notifications can be unrelated or lost; accounting is the completion oracle.
+		let interval = remaining
+			.unwrap_or(Duration::from_millis(10))
+			.min(Duration::from_millis(10));
+		let mut code = 0;
+		let mut key = 0;
+		let mut overlapped: *mut OVERLAPPED = std::ptr::null_mut();
+		let result = unsafe {
+			GetQueuedCompletionStatus(
+				completion_port.0,
+				&mut code,
+				&mut key,
+				&mut overlapped,
+				interval.as_millis().max(1) as u32,
+			)
+		};
+		match result {
+			Ok(()) => {}
+			Err(error) if error.code() == HRESULT::from_win32(WAIT_TIMEOUT.0) => {}
+			Err(error) => return Err(Error::other(error)),
+		}
 	}
+}
 
-	Ok(ControlFlow::Break(()))
+#[cfg(test)]
+mod wait_tests {
+	use super::*;
+
+	#[test]
+	fn invalid_job_is_an_error_even_for_nonblocking_wait() {
+		let job = JobHandle(INVALID_HANDLE_VALUE);
+		let port = PortHandle(INVALID_HANDLE_VALUE);
+		assert!(wait_on_job(job, port, Some(Duration::ZERO)).is_err());
+	}
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -140,8 +140,12 @@ impl JobPort {
 
 impl Drop for JobPort {
 	fn drop(&mut self) {
-		unsafe { CloseHandle(self.job.0) }.ok();
-		unsafe { CloseHandle(self.completion_port.0) }.ok();
+		if self.job.0 != INVALID_HANDLE_VALUE {
+			unsafe { CloseHandle(self.job.0) }.ok();
+		}
+		if self.completion_port.0 != INVALID_HANDLE_VALUE {
+			unsafe { CloseHandle(self.completion_port.0) }.ok();
+		}
 	}
 }
 

--- a/tests/windows_job_lifetime.rs
+++ b/tests/windows_job_lifetime.rs
@@ -1,0 +1,215 @@
+#![cfg(all(
+	windows,
+	feature = "job-object",
+	any(feature = "std", feature = "tokio1")
+))]
+
+use std::{
+	io,
+	os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle},
+	path::{Path, PathBuf},
+	process::{Command, Stdio},
+	time::{Duration, Instant},
+};
+use windows::Win32::{
+	Foundation::{HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT},
+	System::Threading::{
+		OpenProcess, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, TerminateProcess, WaitForSingleObject,
+	},
+};
+
+struct Process(OwnedHandle);
+impl Process {
+	fn open(pid: u32) -> io::Result<Self> {
+		let handle = unsafe { OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_TERMINATE, false, pid) }?;
+		Ok(Self(unsafe { OwnedHandle::from_raw_handle(handle.0) }))
+	}
+	fn alive(&self) -> bool {
+		match unsafe { WaitForSingleObject(HANDLE(self.0.as_raw_handle()), 0) } {
+			WAIT_TIMEOUT => true,
+			WAIT_OBJECT_0 => false,
+			other => panic!("unexpected process wait result: {other:?}"),
+		}
+	}
+	fn stop(&self) {
+		if self.alive() {
+			let _ = unsafe { TerminateProcess(HANDLE(self.0.as_raw_handle()), 99) };
+		}
+		assert_eq!(
+			unsafe { WaitForSingleObject(HANDLE(self.0.as_raw_handle()), 10_000) },
+			WAIT_OBJECT_0
+		);
+	}
+}
+impl Drop for Process {
+	fn drop(&mut self) {
+		self.stop();
+	}
+}
+
+fn until(mut ready: impl FnMut() -> bool) {
+	let deadline = Instant::now() + Duration::from_secs(20);
+	while !ready() {
+		assert!(Instant::now() < deadline, "fixture handshake timed out");
+		std::thread::sleep(Duration::from_millis(2));
+	}
+}
+
+fn fixture_command(mode: &str, directory: &Path) -> io::Result<Command> {
+	let mut command = Command::new(std::env::current_exe()?);
+	command
+		.args(["--exact", "child_fixture", "--nocapture"])
+		.env("PROCESS_WRAP_LIFETIME_MODE", mode)
+		.env("PROCESS_WRAP_LIFETIME_DIRECTORY", directory)
+		.stdin(Stdio::null())
+		.stdout(Stdio::null())
+		.stderr(Stdio::null());
+	Ok(command)
+}
+
+#[test]
+fn child_fixture() -> io::Result<()> {
+	let Some(mode) = std::env::var_os("PROCESS_WRAP_LIFETIME_MODE") else {
+		return Ok(());
+	};
+	let directory = PathBuf::from(std::env::var_os("PROCESS_WRAP_LIFETIME_DIRECTORY").unwrap());
+	if mode == "leaf" {
+		std::fs::write(directory.join("ready"), b"ready")?;
+		until(|| directory.join("release-leaf").exists());
+	} else {
+		let leaf = fixture_command("leaf", &directory)?.spawn()?;
+		std::fs::write(directory.join("pid"), leaf.id().to_string())?;
+		until(|| directory.join("release-leader").exists());
+		// The surviving descendant is the condition these tests exercise.
+		std::process::exit(0);
+	}
+	Ok(())
+}
+
+struct Fixture {
+	_directory: tempfile::TempDir,
+	leader: Process,
+	leaf: Process,
+}
+impl Fixture {
+	fn attach(directory: tempfile::TempDir, pid: u32) -> io::Result<Self> {
+		let leader = Process::open(pid)?;
+		until(|| directory.path().join("ready").exists() && directory.path().join("pid").exists());
+		let leaf = Process::open(
+			std::fs::read_to_string(directory.path().join("pid"))?
+				.parse()
+				.unwrap(),
+		)?;
+		std::fs::write(directory.path().join("release-leader"), b"release")?;
+		until(|| !leader.alive());
+		assert!(leaf.alive());
+		Ok(Self {
+			_directory: directory,
+			leader,
+			leaf,
+		})
+	}
+	#[cfg(feature = "std")]
+	fn release_leaf(&self) -> io::Result<()> {
+		std::fs::write(self._directory.path().join("release-leaf"), b"release")
+	}
+}
+impl Drop for Fixture {
+	fn drop(&mut self) {
+		self.leaf.stop();
+		self.leader.stop();
+	}
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn std_try_wait_tracks_the_job_after_the_leader_exits() -> io::Result<()> {
+	use process_wrap::std::*;
+	let directory = tempfile::tempdir()?;
+	let mut command = CommandWrap::from(fixture_command("leader", directory.path())?);
+	let mut child = command.wrap(JobObject).spawn()?;
+	let fixture = Fixture::attach(directory, child.id())?;
+	assert!(
+		child.try_wait()?.is_none(),
+		"a live descendant keeps the job running"
+	);
+	fixture.release_leaf()?;
+	let status = child.wait()?;
+	assert!(!fixture.leaf.alive());
+	assert_eq!(child.try_wait()?, Some(status));
+	assert_eq!(child.wait()?, status);
+	Ok(())
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn std_wait_does_not_complete_on_a_leader_exit_notification() -> io::Result<()> {
+	use process_wrap::std::*;
+	let directory = tempfile::tempdir()?;
+	let mut command = CommandWrap::from(fixture_command("leader", directory.path())?);
+	let mut child = command.wrap(JobObject).spawn()?;
+	let fixture = Fixture::attach(directory, child.id())?;
+	let (send, receive) = std::sync::mpsc::channel();
+	let waiter = std::thread::spawn(move || {
+		let result = child.wait();
+		send.send(result).unwrap();
+		child
+	});
+	let early = receive.recv_timeout(Duration::from_millis(200));
+	let alive = fixture.leaf.alive();
+	fixture.release_leaf()?;
+	let mut child = waiter.join().unwrap();
+	assert!(
+		early.is_err() && alive,
+		"wait returned while a descendant was still running: {early:?}"
+	);
+	let status = child.wait()?;
+	assert!(!fixture.leaf.alive());
+	assert_eq!(child.try_wait()?, Some(status));
+	Ok(())
+}
+
+#[cfg(feature = "tokio1")]
+#[tokio::test]
+async fn tokio_cancelled_wait_does_not_cache_the_leader_as_job_completion() -> io::Result<()> {
+	use process_wrap::tokio::*;
+	let directory = tempfile::tempdir()?;
+	let mut command = CommandWrap::from(tokio::process::Command::from(fixture_command(
+		"leader",
+		directory.path(),
+	)?));
+	let mut child = command.wrap(JobObject).spawn()?;
+	let fixture = Fixture::attach(directory, child.id())?;
+	assert!(child.try_wait()?.is_none());
+	assert!(
+		tokio::time::timeout(Duration::from_millis(200), child.wait())
+			.await
+			.is_err()
+	);
+	assert!(
+		child.try_wait()?.is_none(),
+		"cancelled wait must not cache leader completion"
+	);
+	child.start_kill()?;
+	let status = child.wait().await?;
+	assert!(!fixture.leaf.alive());
+	assert_eq!(child.wait().await?, status);
+	assert_eq!(child.try_wait()?, Some(status));
+	Ok(())
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn std_kill_and_wait_finishes_descendant_termination() -> io::Result<()> {
+	use process_wrap::std::*;
+	let directory = tempfile::tempdir()?;
+	let mut command = CommandWrap::from(fixture_command("leader", directory.path())?);
+	let mut child = command.wrap(JobObject).spawn()?;
+	let fixture = Fixture::attach(directory, child.id())?;
+	child.start_kill()?;
+	let status = child.wait()?;
+	assert!(!fixture.leaf.alive());
+	assert_eq!(child.wait()?, status);
+	assert_eq!(child.try_wait()?, Some(status));
+	Ok(())
+}

--- a/tests/windows_job_lifetime.rs
+++ b/tests/windows_job_lifetime.rs
@@ -179,7 +179,7 @@ async fn tokio_cancelled_wait_does_not_cache_the_leader_as_job_completion() -> i
 		directory.path(),
 	)?));
 	let mut child = command.wrap(JobObject).spawn()?;
-	let fixture = Fixture::attach(directory, child.id())?;
+	let fixture = Fixture::attach(directory, child.id().expect("leader is still running"))?;
 	assert!(child.try_wait()?.is_none());
 	assert!(
 		tokio::time::timeout(Duration::from_millis(200), child.wait())


### PR DESCRIPTION
Windows JobObject waits can report completion while a descendant is still running after the leader exits. The existing completion-port helper accepts any notification, `try_wait` reports only the leader status, and both frontends cache that status before confirming job completion.

This repair tracks process-creation notifications, retains process handles until they signal exit, and reconciles the observed process count against job accounting. Both `wait` and `try_wait` cache completion only after the whole observed job has finished. Lost or inconsistent notification evidence returns an I/O error instead of reporting successful cleanup.

The retained handles matter: an earlier accounting-only implementation fixed normal waits but still returned early after `TerminateJobObject`. Both std and Tokio cancellation regression tests detected that distinction on native Windows.

Tokio uses finite background waits with independently owned job/port handles and shared observation state. Cancelling a wait future cannot leave an indefinite worker borrowing handles that the child wrapper subsequently closes. `into_inner` preserves its existing detached-job behavior while releasing the added observation resources.

No public API or dependency version changes are required. The existing `job-object` feature additionally enables the Windows SystemServices bindings for notification constants.

The synthetic fixture launches this test executable as a leader and descendant, with all standard streams disconnected. A handshake holds the descendant alive after the leader exits; independently retained process handles verify liveness and cleanup. Coverage includes nonblocking waits, normal completion, explicit termination, repeated waits, a cancelled Tokio wait, inconsistent observation counts and invalid handles.

Verification at `699d18b6c6e6a926f27c807a87b9fb1fa3bc8dc4`:

- Native Windows 10.0.26100.0, x86_64-pc-windows-msvc, Rust 1.97.1: formatting and strict Clippy passed; all-feature/all-target tests passed (99 passed, two existing subprocess helpers ignored).
- Applied only the new integration tests to unchanged upstream `1d1cc53c5c3f9c2e8bf4ae0459d780a616dc1015`; the leader-exit `try_wait` regression failed with the expected live-descendant assertion.
- A separate native public-API probe changed from three lifetime violations to zero: `try_wait` and `wait` remain incomplete while the descendant is alive, and termination plus `wait` completes with the descendant signalled exited.
- macOS all-feature/all-target tests and formatting passed. Strict macOS Clippy is blocked by the existing unused `nix::errno::Errno` import in `src/std/core.rs:378`; that unrelated import is unchanged.

The finite wait interval is not a hard operating-system termination deadline. Spawn/setup-failure cleanup is outside this change.

References:
- https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_associate_completion_port
- https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_accounting_information
- https://learn.microsoft.com/en-us/windows/win32/procthread/terminating-a-process
